### PR TITLE
docs: 新增爬蟲文件索引與測試說明

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,56 @@
 - [ap_common_firebase](https://pub.dev/packages/ap_common_firebase)：串接 Firebase 中校務通會使用到的功能
 - [ap_common_plugin](https://pub.dev/packages/ap_common_plugin)：校務通系列的原生套件，目前支援 Android 的 課堂桌面小工具
 
+## 文件索引
+
+第一次接觸專案的人從這裡開始：
+
+| 文件 | 內容 |
+|---|---|
+| [`packages/nsysu_crawler/README.md`](packages/nsysu_crawler/README.md) | 純 Dart 爬蟲 package 的公開 API、bootstrap 範例、測試方式 |
+| [`packages/nsysu_crawler/docs/endpoint-catalog.md`](packages/nsysu_crawler/docs/endpoint-catalog.md) | 所有 NSYSU endpoint 的 method / encoding / 成功 sentinel / 已知坑 |
+
+## 測試
+
+### Flutter app 測試
+
+```bash
+flutter test test/
+```
+
+目前 app 端的 widget test 還少（見 #97），歡迎補。
+
+### 爬蟲測試（純 Dart，不需 flutter）
+
+爬蟲已抽成獨立 package `packages/nsysu_crawler/`，分三層測試：
+
+```bash
+cd packages/nsysu_crawler
+
+# 1. Hermetic — 單元測試 + JSON 序列化 + 工具函式，預設、不打網路
+dart test
+
+# 2. live-anonymous — 連到真站做連線檢查 + 校車（不需帳密）
+dart test -P live-anonymous -r expanded
+
+# 3. live — 含 selcrs / 畢業審查 / 學雜費，需要學生帳密
+NSYSU_USER=B12345678 NSYSU_PASS=xxx dart test -P live -r expanded
+```
+
+完整命令、PII redact、`NSYSU_HTTP_LOG=1` 等選項見 [package README 的 Tests 段](packages/nsysu_crawler/README.md#tests)。
+
+### CI 自動化
+
+| Workflow | 觸發 | 功能 |
+|---|---|---|
+| [`Build Test`](.github/workflows/workflow.yml) | PR / push to master | Android / iOS / Windows 建置驗證 |
+| [`Crawler Tests`](.github/workflows/test.yml) | PR / push to master | 跑 nsysu_crawler 的 hermetic dart test，亞秒級 |
+| [`Crawler Monitor`](.github/workflows/crawler-monitor.yml) | 每天 08:00 TPE + 手動觸發 | 打真站跑 live tests，失敗發 Discord 通知並分類「網站異常」🔴 / 「結構異常」🟡 |
+
+設 secrets：repo Settings → Secrets and variables → Actions
+- `NSYSU_USERNAME` / `NSYSU_PASSWORD`：跑 cron 的測試帳號（**用 alt account，不要日常帳號**）
+- `DISCORD_WEBHOOK_URL`：失敗通知用
+
 ## 爬蟲
 
 邏輯以需要登入做系統區隔，若有功能有問題可向 [中山大學軟體工程組執掌查詢](https://lis.nsysu.edu.tw/p/405-1001-180580,c1173.php) 聯絡

--- a/packages/nsysu_crawler/README.md
+++ b/packages/nsysu_crawler/README.md
@@ -21,7 +21,7 @@ import 'package:nsysu_crawler/nsysu_crawler.dart';
 
 | Helper | 主要方法 | 是否需登入 |
 |---|---|---|
-| `SelcrsHelper` | `login`, `getUserInfo`, `getCourseSemesterData`, `getCourseData`, `getScoreSemesterData`, `getScoreData`, `changeMail`, `getUsername` | ✅ |
+| `SelcrsHelper` | `login`, `getUserInfo`, `getCourseSemesterData`, `getCourseData`, `getScoreSemesterData`, `getScoreData`, `changeMail`, `getUsername`,`getPreScoreData` | ✅ |
 | `GraduationHelper` | `login`, `getGraduationReport` | ✅（獨立 session）|
 | `TuitionHelper` | `login`, `getData`, `downloadFdf` | ✅（明文密碼，學校系統限制）|
 | `BusHelper` | `getBusInfoList(languageCode:)`, `getBusTime(languageCode:, busInfo:)` | ❌ |

--- a/packages/nsysu_crawler/README.md
+++ b/packages/nsysu_crawler/README.md
@@ -4,31 +4,61 @@ Pure-Dart crawler / API client for NSYSU 校務系統. Lifted out of the
 `nsysu_ap` Flutter app so it can be reused server-side, in a CLI, or in a
 second native client without dragging Flutter SDK dependencies along.
 
-Runs on `dart test` (no `flutter` required).
+`dart test` 執行（不需 `flutter`）。
 
-## Public surface
+## 文件索引
+
+- [Endpoint catalog](docs/endpoint-catalog.md) — 每個學校 endpoint 的 method / encoding / sentinel
+- 上層說明（測試、CI、貢獻流程）見 [專案根 README](../../README.md)
+
+## Public API
 
 ```dart
 import 'package:nsysu_crawler/nsysu_crawler.dart';
+```
 
-// Helpers (each is a singleton via `.instance`)
-SelcrsHelper       // login + user info + course + score
-GraduationHelper   // login + graduation report
-TuitionHelper      // login + tuition list + PDF download
-BusHelper          // bus info + arrival times (no creds)
+### 4 個 helper（皆為 singleton，透過 `.instance` 取用）
 
-// Abstractions (NoOp by default; host app injects real impls at bootstrap)
-CrashReporter      // SelcrsHelper.instance.crashReporter
-AnalyticsLogger    // SelcrsHelper.instance.analyticsLogger
+| Helper | 主要方法 | 是否需登入 |
+|---|---|---|
+| `SelcrsHelper` | `login`, `getUserInfo`, `getCourseSemesterData`, `getCourseData`, `getScoreSemesterData`, `getScoreData`, `changeMail`, `getUsername` | ✅ |
+| `GraduationHelper` | `login`, `getGraduationReport` | ✅（獨立 session）|
+| `TuitionHelper` | `login`, `getData`, `downloadFdf` | ✅（明文密碼，學校系統限制）|
+| `BusHelper` | `getBusInfoList(languageCode:)`, `getBusTime(languageCode:, busInfo:)` | ❌ |
 
-// Locale / debug
+### 2 個抽象介面（NoOp 預設，host app 注入真實實作）
+
+```dart
+abstract interface class CrashReporter {
+  void recordError(Object error, StackTrace stack, {String? reason});
+  void setCustomKey(String key, Object value);
+}
+
+abstract interface class AnalyticsLogger {
+  void logTimeEvent(String name, double seconds);
+}
+```
+
+掛上實作：
+```dart
+SelcrsHelper.instance
+  ..crashReporter = MyFirebaseCrashReporter()
+  ..analyticsLogger = MyFirebaseAnalyticsLogger();
+```
+
+### Locale / debug
+
+```dart
+// 預設 'zh'，host 在 bootstrap 時改成讀 slang locale
 SelcrsHelper.instance.languageProvider = () => 'zh'; // or 'en'
+
+// !bool.fromEnvironment('dart.vm.product')
 const bool kCrawlerDebugMode = ...;
 ```
 
 ## Bootstrap from the host Flutter app
 
-`lib/utils/crawler_bootstrap.dart` in `nsysu_ap` is the canonical example:
+`lib/utils/crawler_bootstrap.dart` in `nsysu_ap` 是參考實作：
 
 ```dart
 void bootstrapCrawler() {
@@ -40,29 +70,73 @@ void bootstrapCrawler() {
 }
 ```
 
-Call `bootstrapCrawler()` from `main()` after Firebase init, before `runApp`.
+在 `main()` 內 Firebase init 之後、`runApp` 之前呼叫一次。
 
 ## Tests
 
-```bash
-# Hermetic unit tests (default — fast, no network)
-dart test
+三層測試金字塔：
 
-# Bus endpoints (no creds required)
-dart test -P live-anonymous -r expanded
+| 層 | 命令 | 跑哪些 | 何時跑 |
+|---|---|---|---|
+| Hermetic | `dart test` | abstractions、codec、model JSON、`redact()`、`currentAcademicSemester()` | 每次 `dart test` |
+| Live (anonymous) | `dart test -P live-anonymous -r expanded` | 3 個 health check probe + bus（不需 creds）| 本機 debug bus、CI 排程 |
+| Live (authenticated) | `NSYSU_USER=… NSYSU_PASS=… dart test -P live -r expanded` | selcrs + graduation + tuition 全套 | 本機需要打真站 / CI 排程 |
 
-# Selcrs / Graduation / Tuition (requires creds)
-NSYSU_USER=B12345678 NSYSU_PASS=xxx dart test -P live -r expanded
+跑出來範例：
+```
+[live] login as B•••••••6 (score + course endpoints)
+[live]   ← isLogin=true result=ApiSuccess<GeneralResponse>
+[live] GET /menu4/tools/changedat.asp (user info)
+[live]   ← id=B•••••••6 name=梁• dept=資•••••系 class=資•••
 ```
 
-`-P live` and `-P live-anonymous` use the `expanded` reporter so each request
-hit (`→ METHOD URL` / `← STATUS path`) is printed inline. See
-`test/live/_dio_logging.dart` for the interceptor.
+PII（學號 / 姓名 / 系所 / 班級 / 課名）用 `redact()` mask 中間字。
+
+要看每個 dio request 的 URL（跟 redirect chain）：
+```bash
+NSYSU_HTTP_LOG=1 dart test -P live -r expanded
+```
+詳見 `test/live/_helpers.dart`。
 
 ### Local creds via direnv
 
-Copy `.envrc.example` → `.envrc`, fill in your creds, run `direnv allow`.
-`.envrc` is gitignored at the repo root.
+複製 `.envrc.example` → `.envrc`、填入 creds、`direnv allow`。`.envrc` 已被根 `.gitignore` 排除。
 
-> **Never** commit credentials. If you accidentally paste them in a chat,
-> commit, or PR, change your selcrs password immediately.
+> **絕對不要 commit creds**。如果不小心貼進 chat / commit / PR，**馬上去 selcrs 改密碼**。
+
+### CI
+
+- 每個 PR：`.github/workflows/test.yml`（hermetic dart test only，亞秒級）
+- 每天 08:00 TPE：`.github/workflows/crawler-monitor.yml`（live + live-anonymous，失敗時發 Discord）
+
+## Architecture（簡述）
+
+```
+nsysu_crawler/
+├── lib/
+│   ├── nsysu_crawler.dart                # 公開 barrel
+│   └── src/
+│       ├── abstractions/                 # CrashReporter / AnalyticsLogger 介面
+│       ├── helpers/                      # 4 個 helper（dio + cookie + 解析串接）
+│       ├── models/                       # Bus / Score / Tuition / Graduation 等
+│       ├── parsers/                      # pure HTML parser（fixture-testable）
+│       └── utils/
+│           ├── big5/                     # BIG-5 codec
+│           └── codec_utils.dart          # base64md5 / uriEncodeBig5
+└── test/
+    ├── abstractions_test.dart
+    ├── codec_utils_test.dart
+    ├── models_test.dart
+    ├── live/                             # 帶 @Tags(['live'/'live-anonymous'])
+    │   ├── _helpers.dart                 # redact / currentAcademicSemester / dio logger
+    │   ├── _helpers_test.dart
+    │   ├── bus_live_test.dart
+    │   ├── graduation_live_test.dart
+    │   ├── health_check_live_test.dart   # connectivity probes
+    │   ├── selcrs_live_test.dart
+    │   └── tuition_live_test.dart
+    ├── fixtures/                         # 真實 HTML / JSON 樣本，給 parser tests 用
+    └── parsers/                          # fixture-based parser tests
+```
+
+不依賴 Flutter SDK；`pubspec.yaml` 只列 `ap_common_core` + `dio` 系列 + `html` + `crypto` + `sprintf`。

--- a/packages/nsysu_crawler/docs/endpoint-catalog.md
+++ b/packages/nsysu_crawler/docs/endpoint-catalog.md
@@ -1,0 +1,130 @@
+# Endpoint Catalog
+
+每個 NSYSU 真實 endpoint、用什麼 method、回什麼編碼、成功的辨識方式。
+學校沒有官方 API 文件，這份是我們從 prod 觀察 + 試錯整理出來的——更動 helper / parser 之前先看這份。
+
+---
+
+## 慣例
+
+- **Sentinel** 欄位寫的是「helper 怎麼判斷成功」。對 `selcrs` / `tfstu` 系列的登入流程，學校 server 不回 200/JSON，而是用 `302 + Location` 跳轉表示登入成功；helper 接到 `DioException` 但 `statusCode == 302` 才算對。
+- **Encoding** 欄是 response body 的字元集——選課/成績系統的 HTML 是 BIG-5（`parse(text, encoding: 'BIG-5')`），其它新系統大多 UTF-8。
+- **Timeout text** 欄是 session 失效時 server 回的中文字串；helper 偵測到後會自動 reLogin（最多 5 次）。
+
+---
+
+## 1. 選課系統 — `selcrs.nsysu.edu.tw`
+
+### 1.1 登入（兩段式：成績系統 → 選課系統）
+
+| Path | Method | Body | Sentinel | 備註 |
+|---|---|---|---|---|
+| `/scoreqry/sco_query_prs_sso2.asp` | POST | `SID`, `PASSWD`(base64md5), `ACTION=0`, `INTYPE=1` | `302 → sco_query.asp?action=101` | 成績系統第一道 SSO；錯密碼回 200 含「資料錯誤請重新輸入」 |
+| `/menu4/Studcheck_sso2.asp` | POST | `stuid`, `SPassword`(base64md5) | `302 → main_frame.asp` | 選課系統第二道；錯密碼回 200 含「學號碼密碼不符」；需要填表回「請先填寫」(401) |
+
+實作：`SelcrsHelper.login()`。失敗會 `changeSelcrsUrl()`（學校有 4 台 mirror），重試上限 5 次。
+
+### 1.2 個人資訊
+
+| Path | Method | Helper | Encoding | Sentinel | Timeout text |
+|---|---|---|---|---|---|
+| `/menu4/tools/changedat.asp` | GET | `getUserInfo` / `parseUserInfo` | UTF-8 | 200 + 至少 10 個 `<td>` | 「請重新登錄」 |
+| `/menu4/tools/changedat.asp` | POST `T1=<email>` | `changeMail` | UTF-8 | 同上 | 同上 |
+
+### 1.3 課表
+
+| Path | Method | Body | Encoding | Helper |
+|---|---|---|---|---|
+| `/menu4/query/stu_slt_up.asp` | POST | — | UTF-8 | `getCourseSemesterData` |
+| `/menu4/query/stu_slt_data.asp` | POST | `stuact=B`, `YRSM=<年學期>`, `Stuid=<學號>`, `B1=%BDT%A9w%B0e%A5X` | UTF-8 | `getCourseData` |
+
+`YRSM` 拼接：學年（ROC，3 碼）+ 學期值（`1`=上、`2`=下），例如 `1132` = 113 學年下學期。
+課程標題的 `<a>` 內文以 `<br>` 分隔中／英；`languageProvider()` 決定取哪一段。
+
+### 1.4 成績
+
+| Path | Method | Query / Body | Encoding | Helper |
+|---|---|---|---|---|
+| `/scoreqry/sco_query.asp?ACTION=702&KIND=2&LANGS={cht\|eng}` | POST | — | **BIG-5** | `getScoreSemesterData` |
+| `/scoreqry/sco_query.asp?ACTION=804&KIND=2&LANGS={cht\|eng}` | POST | `SYEAR=<年>`, `SEM=<1\|2>` | **BIG-5** | `getScoreData` |
+| `/scoreqry/sco_query.asp?ACTION=814&KIND=1&LANGS={cht\|eng}` | POST | `CRSNO=<課號>` | **BIG-5** | `getPreScoreData`（選擇性 — 期中時撈授課老師預給分） |
+
+`LANGS` 跟 selcrs 的中英版本綁定，由 `SelcrsHelper.language` 決定（`languageProvider()` 回 `'en'` 時填 `eng`，否則 `cht`）。
+
+### 1.5 學號查詢（找帳號用）
+
+| Path | Method | Body | Encoding |
+|---|---|---|---|
+| `/newstu/stu_new.asp?action=16` | POST | `CNAME`(big5 + uri-encoded), `T_CID`(身分證末四碼), `B1=%BDT%A9w%B0e%A5X` | BIG-5 |
+
+實作：`SelcrsHelper.getUsername`。送中文姓名前要先 `uriEncodeBig5(name)`。
+
+---
+
+## 2. 畢業審查 — `selcrs.nsysu.edu.tw/gadchk/`（同 host，獨立 session）
+
+| Path | Method | Body | Sentinel |
+|---|---|---|---|
+| `/gadchk/gad_chk_login_prs_sso2.asp` | POST | `SID`, `PASSWD`(base64md5), `PGKIND=GAD_CHK`, `ACTION=0` | `302 → gad_chk.asp?action=1` |
+| `/gadchk/gad_chk_stu_list.asp?stno=<學號>&KIND=5&frm=1` | GET | — | 200 |
+
+注意：`GraduationHelper` 跟 `SelcrsHelper` **不共用 cookie jar**，需要獨立登入。錯密碼回 200 含「資料錯誤請重新輸入」(401)。
+
+---
+
+## 3. 學雜費 — `tfstu.nsysu.edu.tw`
+
+| Path | Method | Body | Encoding | Sentinel |
+|---|---|---|---|---|
+| `/tfstu/tfstu_login_chk.asp` | POST | `ID=<學號>`, `passwd=<明文>` | — | `302 → tfstudata.asp?act=11` |
+| `/tfstu/tfstudata.asp?act=11` | GET | — | **BIG-5** | 200 + `tbody[1]`；空清單時 body 含「沒有合乎查詢條件的資料」 |
+| `/tfstu/<serialNumber>` | GET | — | bytes (PDF) | 200 |
+
+⚠️ 這個系統的密碼**不做 hashing**——直接把明碼 POST 上去。架構決定，不是我們的選擇。
+列表 row 的 `td[2]` 是混合編碼（中文 BIG-5 + 英文 ASCII 交錯），我們依 codeUnit < 200 拆雙語版本。
+PDF 序號從 `<a onclick="javascript:window.location.href='...'">` 解出。
+
+---
+
+## 4. 校車 — `ibus.nsysu.edu.tw` + GitHub Pages CDN
+
+| Path | Method | Body | Encoding | Helper |
+|---|---|---|---|---|
+| `https://nsysu-code-club.github.io/nsysu-bus/bus_info_data_{zh\|en}.json` | GET | — | UTF-8 | `getBusInfoList` |
+| `https://ibus.nsysu.edu.tw/API/RoutePathStop.aspx?<timestamp>` | POST (FormData) | `RID`, `C={zh\|en}`, `CID` | UTF-8 | `getBusTime` |
+
+校車不需要登入。`getBusInfoList` 抓的不是學校 server，是社團維護的 [nsysu-bus](https://github.com/nsysu-code-club/nsysu-bus) GitHub Pages CDN（學校 ibus 沒有公開的「全部路線」endpoint，只能查單條路線到站時間）。
+
+URL query 後綴 `?<millisecondsSinceEpoch>` 是用來破 CDN cache，不是 auth。
+
+---
+
+## 5. 其它（已知但目前未實作）
+
+這些 endpoint 在 root README 的爬蟲清單裡有列、但尚未抽 helper：
+
+- 歷年學生缺曠課資料（選課系統）
+- 通識教育講座次數查詢（選課系統）— 對應 #21
+- 修改登錄密碼（選課系統）— 對應 #22
+- 學生預警查詢（成績系統）— 對應 #23
+- 各類所得郵局劃帳暨歸戶查詢系統 — 對應 #24
+- 課程課綱（選課系統）— 對應 #35
+- 收發室（信件查詢）— 對應 #45
+- 總務處維修系統
+- 歷年成績單
+- 借書系統 — 對應 #36
+
+加新 endpoint 時的流程：把真實 HTML 存進 `test/fixtures/`、寫 parser pure function、寫 fixture-based unit test、最後在 helper 裡 wire 起來——詳見 `docs/adding-an-endpoint.md`（**TODO**：實作第一個新 endpoint 時順便寫）。
+
+---
+
+## 觀察新 endpoint 的工具
+
+跑 live test 時 set `NSYSU_HTTP_LOG=1`：
+
+```bash
+NSYSU_USER=... NSYSU_PASS=... NSYSU_HTTP_LOG=1 \
+  dart test -P live -r expanded
+```
+
+每個 dio request 的 method + URL（含 redirect chain）都會印出來，看完就知道 helper 實際打了哪些。對 reverse-engineer 新 endpoint 也方便。


### PR DESCRIPTION
### **User description**
## 摘要

讓第一次接觸專案的人知道：
1. 爬蟲怎麼用、API 在哪查、bootstrap 怎麼接 — 看 package README
2. 學校 endpoint 的細節（method / encoding / sentinel / 已知坑）— 看 endpoint catalog
3. 怎麼跑測試（三層）— 根 README 直接列命令
4. CI 自動化在做什麼 — 根 README 表格列出 workflow

## 主要變更

### 新增：`packages/nsysu_crawler/docs/endpoint-catalog.md`

每個學校 endpoint 一張表，分五區：
- 選課系統（登入兩段式 / 個人資訊 / 課表 / 成績 / 學號查詢）
- 畢業審查（獨立 session）
- 學雜費（含「明文密碼」「td 雙語混排」這種坑）
- 校車（社團維護的 GitHub Pages CDN + ibus API）
- 已知但尚未實作（對應 #21–#24, #35, #36, #45 等 issue）

每筆寫清楚 method、encoding、sentinel（特別是「302 = 成功」這種反直覺的）、相關 helper。學校沒官方文件，這份是觀察 prod 整理出來的，更動 helper / parser 之前先看這份。

### 擴充：`packages/nsysu_crawler/README.md`

- 加文件索引（連到 endpoint catalog 跟根 README）
- 公開 API 從 prose 改成 4 個 helper × 主要方法的表格
- 三層測試金字塔（hermetic / live-anonymous / live）整理成表 + 指令範例
- Architecture 段加目錄樹，標註 `parsers/` 跟 `test/parsers/` 在 #111 補上
- 修正 stale 引用 `_dio_logging.dart` → `_helpers.dart`（#110 改的名）

### 更新：根 `README.md`

在「使用套件」跟「爬蟲」之間加兩個新段：

- **文件索引**：表格列出 package README + endpoint catalog 兩份起始文件
- **測試**：
  - Flutter app 測試（`flutter test test/`，附帶提到 #97）
  - 爬蟲三層測試（`dart test` / `-P live-anonymous` / `-P live`）
  - CI 自動化表（Build Test + Crawler Monitor），附 secrets 設置 hint

## 沒做的事 / 未來補

- `Crawler Tests`（PR-time hermetic dart test）workflow 是 #111 的範圍，尚未在 master 上，所以根 README 暫時只列 `Build Test` 跟 `Crawler Monitor` 兩個 workflow；#111 merge 後可加進來
- Adding-an-endpoint guide 還沒寫——等 #21–#24 任一個 issue 真的開始實作時再附上 step-by-step 範例會比較準
- ADR / architecture overview 等抽象文件先不寫，等需求出現再補

## 測試計畫

純文件，沒程式變更：

- [x] `flutter analyze lib` 沒新 warning
- [x] 在 GitHub web UI preview 兩份 README 跟 endpoint catalog 的 markdown 顯示
- [x] 點 README 內每個檔案連結確認都連得到（package README ↔ 根 README ↔ endpoint catalog）

## 相關 issues

- 部分回應 #98（更新開發文件）— 把爬蟲層相關文件補齊
- Refs #97（測試覆蓋率）— 文件中明確指出 widget test 未補齊


___

### **PR Type**
Documentation, Tests


___

### **Description**
- 新增學校 API 端點詳細目錄。

- 更新專案根 README 測試指南。

- 詳述爬蟲套件 API 與測試。

- 新增 CI 自動化流程說明。


___

