### PR TITLE
fix(manifest): remove READ_MEDIA_IMAGES permission for Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
     <!-- Permissions options for the `storage` group -->
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+
     <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
 
     <queries>


### PR DESCRIPTION
This pull request makes a minor update to the Android manifest permissions. Specifically, it removes the `READ_MEDIA_IMAGES` permission, to reduce unnecessary permissions or to comply with updated Android best practices. No other changes are included.

- Removed the `android.permission.READ_MEDIA_IMAGES` permission from `AndroidManifest.xml` to streamline media access permissions.