### PR TITLE
Remove READ_MEDIA_IMAGES permission from Android manifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
     <!-- Permissions options for the `storage` group -->
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+
     <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
 
     <queries>


### PR DESCRIPTION
This pull request makes a minor update to the Android app's manifest file, specifically related to storage permissions. The `READ_MEDIA_IMAGES` permission has been removed, to comply with updated Android guidelines.

- Android permissions:
  * Removed the `android.permission.READ_MEDIA_IMAGES` permission from `AndroidManifest.xml`.