### PR TITLE
chore(ios): disable swift package manager to pin firebase via cocoapods

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,9 @@ dependency_overrides:
 
 flutter:
 
+  config:
+    enable-swift-package-manager: false
+
   uses-material-design: true
   assets:
     - assets/images/


### PR DESCRIPTION
### **User description**
## 變更摘要

關閉 Flutter 的 Swift Package Manager 整合,讓 iOS 相依套件(特別是 Firebase)一律走回 CocoaPods 解析,修掉 CI 上的 iOS build 失敗。

## 問題背景

最近 PR 的 iOS job 開始紅,錯誤是 SPM 的 Target Integrity 硬檢查:

```
The package product 'firebase-core' requires minimum platform version 15.0
for the iOS platform, but this target supports 14.0
```

根因:

- 專案其實**尚未** migrate 到 SPM —— `project.pbxproj` 沒有任何 SPM package reference,Firebase 在 `Podfile.lock` 釘在 `12.9.0`(CocoaPods)。
- 但 self-hosted runner 上 Flutter 的 `enable-swift-package-manager` feature flag 是開的,只要 plugin 附 `Package.swift`(`firebase_*` 都有),Flutter 就會在 build 當下臨時把它改走 SPM。
- SPM 對 platform 版本是硬檢查(app target 14 < Firebase 要求的 15 直接 error),CocoaPods 則只 warning。加上沒有 committed 的 `Package.resolved`,SPM 解析不穩定,所以同一份 code 會時綠時紅。

## 變更內容

- `pubspec.yaml` 的 `flutter:` 區塊加上 `disable-swift-package-manager: true`(per-project 關閉,進 repo、不依賴 runner 全域狀態)。

關閉後 Firebase 走回 CocoaPods:用既有 `Podfile.lock`(12.9.0,deterministic),且 Podfile 的 `post_install` 已強制所有 Pods target 為 iOS 15,app target 留在 14 也能 build。**不升任何 pod 版本,也不動 deployment target。**

## 測試方式

- CI 的 Build iOS job 應轉綠。
- 本地驗證:`flutter clean && flutter pub get && (cd ios && pod install)` 後 `flutter build ios --no-codesign`。

## 影響範圍與風險

- 只影響 iOS 相依解析路徑(SPM → CocoaPods),Android / Windows 不受影響。
- 維持 CocoaPods 現狀,無 migration、無版本升級風險。
- 切換後需清一次 ephemeral 的 SPM 產物(`flutter clean`),否則殘留可能干擾本地 build。


___

### **PR Type**
Enhancement


___

### **Description**
- 禁用 Flutter 的 Swift Package Manager。

- 解決 iOS 建置失敗問題。

- 確保 Firebase 透過 CocoaPods 解析。

- 穩定 iOS 相依套件解析。


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Flutter iOS 建置"] --> B{"禁用 Swift Package Manager"};
  B -- "強制使用" --> C["CocoaPods 解析 Firebase"];
  C --> D["解決 iOS 建置失敗"];
```

