### PR TITLE
ci(windows): 修復 MSVC experimental coroutine 編譯 error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,3 +134,8 @@ jobs:
       - run: flutter pub get
       - name: Build windows
         run: flutter build windows --release
+        env:
+          # 新版 MSVC (VS18 / 14.51) 把 <experimental/coroutine> 從 warning 升成硬 error (STL1011)，
+          # flutter_inappwebview_windows、gal 等 plugin 仍在使用。透過 CL 環境變數注入 silence macro，
+          # 確保涵蓋所有 plugin 的編譯單元（在 windows/CMakeLists.txt 設 define 無法傳到 plugin sub-project）。
+          CL: /D_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS


### PR DESCRIPTION
### **User description**
## 變更摘要

修復 Windows CI 全面 fail 的問題，原因是 GitHub `windows-latest` runner 升級 MSVC toolchain 後，第三方 plugin 使用的 `<experimental/coroutine>` 被升級成硬 error。與功能無關，純 CI 修復。

## 問題根因

- `windows-latest` 換成 VS18 / MSVC `14.51.36231` 後，新版 STL 把 `<experimental/coroutine>`、`/await` 從 deprecation warning 升級為硬 error（STL1011）。
- 出錯的是第三方 plugin（`flutter_inappwebview_windows`、`gal`），它們仍 include experimental coroutine header，並非本 app 程式碼。
- 佐證：develop 上次 Windows CI（2026-05-30）為 success；近期 PR（#122、#123）於 2026-06-19 皆以相同錯誤 fail，且 #123 完全未動 C++/CMake。屬環境 regression。

## 變更內容

- `.github/workflows/ci.yml` 的 Build windows step 加上 `CL: /D_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS` 環境變數。
- 用 `CL` 而非在 `windows/CMakeLists.txt` 設 define，是因為 plugin 為 Flutter 另外產生的 sub-project，CMakeLists 的 define 傳不進去；`CL` 由 `cl.exe` 每次編譯讀取，可涵蓋所有編譯單元。

## 測試方式

- 觀察本 PR 的 Build Windows App job 是否由 fail 轉 pass。
- Android / iOS / Analyze & Test 不受影響。

## 影響範圍與風險

- 僅影響 Windows CI build step，不動任何 app 程式碼。
- 屬暫時性 workaround；待上游 plugin 改用 C++20 `<coroutine>` 後可移除。
- 建議 #122 一併移除其 `windows/CMakeLists.txt` 中無效的 `/await` + define 區塊，避免重複且誤導。

https://claude.ai/code/session_01GubRxn5ey7kZN1LSTNEiXY


___

### **PR Type**
Bug fix


___

### **Description**
- 修復 Windows CI 編譯失敗問題。

- 靜默 MSVC 新版編譯器協程警告。

- 確保第三方插件能正常編譯。


___

