### PR TITLE
ci(windows): 修復 Store CD 的 MSVC coroutine 編譯 error

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -191,6 +191,11 @@ jobs:
       - run: flutter pub get
       - name: Build windows
         run: flutter build windows --release --build-number=${{ needs.prepare.outputs.version_code }}
+        env:
+          # 新版 MSVC (VS18 / 14.51) 把 <experimental/coroutine> 從 warning 升成硬 error (STL1011)，
+          # flutter_inappwebview_windows、gal 等 plugin 仍在使用。透過 CL 環境變數注入 silence macro，
+          # 確保涵蓋所有 plugin 的編譯單元（與 ci.yml 一致）。
+          CL: /D_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS
       - name: Zip files
         run: powershell Compress-Archive build\windows\x64\runner\Release\ windows.zip
       - name: Upload artifact


### PR DESCRIPTION
### **User description**
## 變更摘要

承接 #124,補修 `cd.yml`(Store CD)的 Windows build。#124 只修了 `ci.yml`,但 `cd.yml` 有獨立的 Build windows step,仍會撞到相同的 MSVC `<experimental/coroutine>` 硬 error,導致部署失敗。

## 問題

merge #122/#123 後 Store CD 失敗,根因有二:

1. **Windows App job fail**(本 PR 修)：`cd.yml` 的 Build windows 缺 `CL` env → STL1011 硬 error → 產不出 `windows-artifact` → `Create GitHub Release` 連帶 fail(`Artifact not found for name: windows-artifact`)。
2. **iOS Deploy TestFlight fail**(本 PR 不處理,需人工)：`exportArchive Unable to process request - PLA Update available` / `No signing certificate "iOS Distribution" found`。Apple Developer Program License Agreement 有新版待簽,需帳號 holder 至 developer.apple.com 接受後才能簽署。

## 變更內容

- `cd.yml` Build windows step 加上 `CL: /D_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS`,與 #124 對 `ci.yml` 的修法一致。

## 測試方式

- merge 後觀察 Store CD 的 Windows App 與 Create GitHub Release 是否轉 pass。
- iOS job 在 PLA 簽署前仍會 fail,屬預期(與本 PR 無關)。

## 影響範圍與風險

- 僅改 CD 的 Windows build step,不動 app 程式碼。
- 暫時性 workaround,待上游 plugin 改用 C++20 `<coroutine>` 後可移除。

https://claude.ai/code/session_01GubRxn5ey7kZN1LSTNEiXY


___

### **PR Type**
Bug fix


___

### **Description**
- 修復 Store CD Windows 編譯失敗。

- 靜默 MSVC 實驗性協程警告。

- 確保第三方插件正常編譯。


___

