### PR TITLE
feat: 由學校註冊路由提取在學證明

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ fvm dart run tool/install_git_hooks.dart
 - 畢業生審查系統
     - [ ] 歷年成績單
     - [x] 應屆畢業生成績檢核表
+- 教務處註冊系統
+    - [x] 在學證明 PDF 提取與匯出
 - 各類所得劃帳暨歸戶查詢
     - [ ] 各類所得郵局劃帳暨歸戶查詢系統
 - 設定
@@ -126,6 +128,8 @@ NSYSU_USER=B12345678 NSYSU_PASS=xxx dart test -P live -r expanded
       - [x] 學期成績查詢
       - [ ] 歷年成績查詢
   - [x] [畢業審查系統](https://sis.nsysu.edu.tw/SLAMS/SLAMS_student_view.php)
+  - [x] [教務處註冊系統](https://regweb.nsysu.edu.tw/webreg/)
+      - [x] 在學證明 PDF 提取
   - [ ] 總務處維修系統
   - [x] [學生請假系統](https://sso.nsysu.edu.tw/index.php/home/applisturl/0H00/0051)
   - [ ] 新網路大學 To-Do 提示

--- a/lib/l10n/strings.g.dart
+++ b/lib/l10n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 124 (62 per locale)
+/// Strings: 164 (82 per locale)
 ///
-/// Built on 2026-06-18 at 11:52 UTC
+/// Built on 2026-08-30 at 08:50 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/l10n/strings_en.g.dart
+++ b/lib/l10n/strings_en.g.dart
@@ -106,6 +106,31 @@ class AppLocalizationsEn extends AppLocalizations with BaseTranslations<AppLocal
 	@override String get openingBrowserContent => 'This will open an external website in your browser. Continue?';
 	@override String get openingBrowserTitle => 'Open External Website';
 	@override String get visitingUnSafeLink => 'Unsafe link. Please confirm the URL is correct.';
+	@override late final _AppLocalizationsEnrollCertificateEn enrollCertificate = _AppLocalizationsEnrollCertificateEn._(_root);
+}
+
+// Path: enrollCertificate
+class _AppLocalizationsEnrollCertificateEn extends AppLocalizationsEnrollCertificateZhHantTw {
+	_AppLocalizationsEnrollCertificateEn._(AppLocalizationsEn root) : this._root = root, super.internal(root);
+
+	final AppLocalizationsEn _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Certificate of Enrollment';
+	@override String get regenerate => 'Retrieve Again';
+	@override String get retry => 'Try Again';
+	@override String get download => 'Download / Export';
+	@override String get fileName => 'Certificate of Enrollment';
+	@override String get loadingCached => 'Loading the saved certificate...';
+	@override String get retrieving => 'Retrieving the certificate from the university system...';
+	@override String get missingAccount => 'No account was found. Sign in to the app before obtaining a certificate.';
+	@override String get missingCredentials => 'No saved credentials were found. Sign in to the app again before retrieving a new certificate.';
+	@override String get saveFailed => 'The document was retrieved, but the local cache could not be updated.';
+	@override String get notObtained => 'The certificate has not been obtained. Please try again.';
+	@override String get requestTimedOut => 'The university system timed out. Please try retrieving the certificate later.';
+	@override String get requestFailed => 'The certificate could not be retrieved. Check your connection and try again.';
+	@override String get invalidResponse => 'The university system did not return a valid certificate PDF. Check your credentials or try again later.';
+	@override String get downloadFailed => 'The certificate could not be downloaded or exported. Please try again later.';
 }
 
 /// The flat map containing all translations for locale <en>.
@@ -183,6 +208,21 @@ extension on AppLocalizationsEn {
 			'openingBrowserContent' => 'This will open an external website in your browser. Continue?',
 			'openingBrowserTitle' => 'Open External Website',
 			'visitingUnSafeLink' => 'Unsafe link. Please confirm the URL is correct.',
+			'enrollCertificate.title' => 'Certificate of Enrollment',
+			'enrollCertificate.regenerate' => 'Retrieve Again',
+			'enrollCertificate.retry' => 'Try Again',
+			'enrollCertificate.download' => 'Download / Export',
+			'enrollCertificate.fileName' => 'Certificate of Enrollment',
+			'enrollCertificate.loadingCached' => 'Loading the saved certificate...',
+			'enrollCertificate.retrieving' => 'Retrieving the certificate from the university system...',
+			'enrollCertificate.missingAccount' => 'No account was found. Sign in to the app before obtaining a certificate.',
+			'enrollCertificate.missingCredentials' => 'No saved credentials were found. Sign in to the app again before retrieving a new certificate.',
+			'enrollCertificate.saveFailed' => 'The document was retrieved, but the local cache could not be updated.',
+			'enrollCertificate.notObtained' => 'The certificate has not been obtained. Please try again.',
+			'enrollCertificate.requestTimedOut' => 'The university system timed out. Please try retrieving the certificate later.',
+			'enrollCertificate.requestFailed' => 'The certificate could not be retrieved. Check your connection and try again.',
+			'enrollCertificate.invalidResponse' => 'The university system did not return a valid certificate PDF. Check your credentials or try again later.',
+			'enrollCertificate.downloadFailed' => 'The certificate could not be downloaded or exported. Please try again later.',
 			_ => null,
 		};
 	}

--- a/lib/l10n/strings_en.json
+++ b/lib/l10n/strings_en.json
@@ -65,5 +65,22 @@
   "optionCancel": "Cancel",
   "openingBrowserContent": "This will open an external website in your browser. Continue?",
   "openingBrowserTitle": "Open External Website",
-  "visitingUnSafeLink": "Unsafe link. Please confirm the URL is correct."
+  "visitingUnSafeLink": "Unsafe link. Please confirm the URL is correct.",
+  "enrollCertificate": {
+    "title": "Certificate of Enrollment",
+    "regenerate": "Retrieve Again",
+    "retry": "Try Again",
+    "download": "Download / Export",
+    "fileName": "Certificate of Enrollment",
+    "loadingCached": "Loading the saved certificate...",
+    "retrieving": "Retrieving the certificate from the university system...",
+    "missingAccount": "No account was found. Sign in to the app before obtaining a certificate.",
+    "missingCredentials": "No saved credentials were found. Sign in to the app again before retrieving a new certificate.",
+    "saveFailed": "The document was retrieved, but the local cache could not be updated.",
+    "notObtained": "The certificate has not been obtained. Please try again.",
+    "requestTimedOut": "The university system timed out. Please try retrieving the certificate later.",
+    "requestFailed": "The certificate could not be retrieved. Check your connection and try again.",
+    "invalidResponse": "The university system did not return a valid certificate PDF. Check your credentials or try again later.",
+    "downloadFailed": "The certificate could not be downloaded or exported. Please try again later."
+  }
 }

--- a/lib/l10n/strings_zh-Hant-TW.json
+++ b/lib/l10n/strings_zh-Hant-TW.json
@@ -65,5 +65,22 @@
   "optionCancel": "取消",
   "openingBrowserContent": "將使用瀏覽器開啟外部網站，是否繼續？",
   "openingBrowserTitle": "開啟外部網站",
-  "visitingUnSafeLink": "不安全的連結，請確認網址是否正確"
+  "visitingUnSafeLink": "不安全的連結，請確認網址是否正確",
+  "enrollCertificate": {
+    "title": "在學證明",
+    "regenerate": "重新提取",
+    "retry": "重新執行",
+    "download": "下載／匯出",
+    "fileName": "在學證明",
+    "loadingCached": "正在讀取已儲存的在學證明...",
+    "retrieving": "正在向校方系統提取在學證明...",
+    "missingAccount": "找不到目前帳號，請先登入 App 後再取得在學證明。",
+    "missingCredentials": "找不到目前登入帳密，請先重新登入 App 後再重新提取。",
+    "saveFailed": "已取得文件，但無法更新本機快取。",
+    "notObtained": "尚未取得在學證明，請重新執行。",
+    "requestTimedOut": "校方系統回應逾時，請稍後重新提取。",
+    "requestFailed": "無法從校方系統取得在學證明，請確認網路後重試。",
+    "invalidResponse": "校方系統未回傳有效的在學證明 PDF，請確認帳密或稍後重試。",
+    "downloadFailed": "無法下載／匯出在學證明，請稍後再試。"
+  }
 }

--- a/lib/l10n/strings_zh_Hant_TW.g.dart
+++ b/lib/l10n/strings_zh_Hant_TW.g.dart
@@ -241,6 +241,62 @@ class AppLocalizations with BaseTranslations<AppLocale, AppLocalizations> {
 
 	/// zh-Hant-TW: '不安全的連結，請確認網址是否正確'
 	String get visitingUnSafeLink => '不安全的連結，請確認網址是否正確';
+
+	late final AppLocalizationsEnrollCertificateZhHantTw enrollCertificate = AppLocalizationsEnrollCertificateZhHantTw.internal(_root);
+}
+
+// Path: enrollCertificate
+class AppLocalizationsEnrollCertificateZhHantTw {
+	AppLocalizationsEnrollCertificateZhHantTw.internal(this._root);
+
+	final AppLocalizations _root; // ignore: unused_field
+
+	// Translations
+
+	/// zh-Hant-TW: '在學證明'
+	String get title => '在學證明';
+
+	/// zh-Hant-TW: '重新提取'
+	String get regenerate => '重新提取';
+
+	/// zh-Hant-TW: '重新執行'
+	String get retry => '重新執行';
+
+	/// zh-Hant-TW: '下載／匯出'
+	String get download => '下載／匯出';
+
+	/// zh-Hant-TW: '在學證明'
+	String get fileName => '在學證明';
+
+	/// zh-Hant-TW: '正在讀取已儲存的在學證明...'
+	String get loadingCached => '正在讀取已儲存的在學證明...';
+
+	/// zh-Hant-TW: '正在向校方系統提取在學證明...'
+	String get retrieving => '正在向校方系統提取在學證明...';
+
+	/// zh-Hant-TW: '找不到目前帳號，請先登入 App 後再取得在學證明。'
+	String get missingAccount => '找不到目前帳號，請先登入 App 後再取得在學證明。';
+
+	/// zh-Hant-TW: '找不到目前登入帳密，請先重新登入 App 後再重新提取。'
+	String get missingCredentials => '找不到目前登入帳密，請先重新登入 App 後再重新提取。';
+
+	/// zh-Hant-TW: '已取得文件，但無法更新本機快取。'
+	String get saveFailed => '已取得文件，但無法更新本機快取。';
+
+	/// zh-Hant-TW: '尚未取得在學證明，請重新執行。'
+	String get notObtained => '尚未取得在學證明，請重新執行。';
+
+	/// zh-Hant-TW: '校方系統回應逾時，請稍後重新提取。'
+	String get requestTimedOut => '校方系統回應逾時，請稍後重新提取。';
+
+	/// zh-Hant-TW: '無法從校方系統取得在學證明，請確認網路後重試。'
+	String get requestFailed => '無法從校方系統取得在學證明，請確認網路後重試。';
+
+	/// zh-Hant-TW: '校方系統未回傳有效的在學證明 PDF，請確認帳密或稍後重試。'
+	String get invalidResponse => '校方系統未回傳有效的在學證明 PDF，請確認帳密或稍後重試。';
+
+	/// zh-Hant-TW: '無法下載／匯出在學證明，請稍後再試。'
+	String get downloadFailed => '無法下載／匯出在學證明，請稍後再試。';
 }
 
 /// The flat map containing all translations for locale <zh-Hant-TW>.
@@ -318,6 +374,21 @@ extension on AppLocalizations {
 			'openingBrowserContent' => '將使用瀏覽器開啟外部網站，是否繼續？',
 			'openingBrowserTitle' => '開啟外部網站',
 			'visitingUnSafeLink' => '不安全的連結，請確認網址是否正確',
+			'enrollCertificate.title' => '在學證明',
+			'enrollCertificate.regenerate' => '重新提取',
+			'enrollCertificate.retry' => '重新執行',
+			'enrollCertificate.download' => '下載／匯出',
+			'enrollCertificate.fileName' => '在學證明',
+			'enrollCertificate.loadingCached' => '正在讀取已儲存的在學證明...',
+			'enrollCertificate.retrieving' => '正在向校方系統提取在學證明...',
+			'enrollCertificate.missingAccount' => '找不到目前帳號，請先登入 App 後再取得在學證明。',
+			'enrollCertificate.missingCredentials' => '找不到目前登入帳密，請先重新登入 App 後再重新提取。',
+			'enrollCertificate.saveFailed' => '已取得文件，但無法更新本機快取。',
+			'enrollCertificate.notObtained' => '尚未取得在學證明，請重新執行。',
+			'enrollCertificate.requestTimedOut' => '校方系統回應逾時，請稍後重新提取。',
+			'enrollCertificate.requestFailed' => '無法從校方系統取得在學證明，請確認網路後重試。',
+			'enrollCertificate.invalidResponse' => '校方系統未回傳有效的在學證明 PDF，請確認帳密或稍後重試。',
+			'enrollCertificate.downloadFailed' => '無法下載／匯出在學證明，請稍後再試。',
 			_ => null,
 		};
 	}

--- a/lib/pages/enroll_certificate/enroll_certificate_page.dart
+++ b/lib/pages/enroll_certificate/enroll_certificate_page.dart
@@ -9,32 +9,54 @@ import 'package:nsysu_ap/utils/enroll_certificate/enroll_certificate_cache.dart'
 import 'package:nsysu_crawler/nsysu_crawler.dart';
 import 'package:printing/printing.dart';
 
+/// Supplies the credentials used by [EnrollCertificatePage].
 typedef EnrollmentCertificateCredentialsProvider =
     EnrollmentCertificateCredentials Function();
+
+/// Retrieves a fresh enrollment certificate PDF.
 typedef EnrollmentCertificateDownload =
     Future<Uint8List> Function({
       required String username,
       required String password,
     });
+
+/// Reads an account-scoped cached enrollment certificate PDF.
 typedef EnrollmentCertificateCacheReader =
     Future<Uint8List?> Function({required String username});
+
+/// Writes an account-scoped cached enrollment certificate PDF.
 typedef EnrollmentCertificateCacheWriter =
     Future<void> Function({required String username, required Uint8List bytes});
+
+/// Exports the displayed PDF to the platform share/save flow.
 typedef EnrollmentCertificatePdfExporter =
     Future<bool> Function({required Uint8List bytes, required String fileName});
+
+/// Builds the PDF viewer for a validated enrollment certificate.
 typedef EnrollmentCertificatePdfViewBuilder =
     Widget Function(BuildContext context, Uint8List bytes, String fileName);
 
+/// Username/password pair used to retrieve an enrollment certificate.
 class EnrollmentCertificateCredentials {
   const EnrollmentCertificateCredentials({
     required this.username,
     required this.password,
   });
 
+  /// Student ID used by RegWeb.
   final String username;
+
+  /// Password for the school account.
   final String password;
 }
 
+/// Loads, refreshes, displays, and exports the current user's enrollment
+/// certificate PDF.
+///
+/// The optional callbacks keep network, cache, export, and PDF rendering
+/// injectable for widget tests. In production, the page reads the active app
+/// credentials, uses [EnrollmentCertificateHelper] for RegWeb, and stores the
+/// last valid PDF in [EnrollCertificateCache].
 class EnrollCertificatePage extends StatefulWidget {
   const EnrollCertificatePage({
     super.key,

--- a/lib/pages/enroll_certificate/enroll_certificate_page.dart
+++ b/lib/pages/enroll_certificate/enroll_certificate_page.dart
@@ -1,0 +1,417 @@
+import 'dart:typed_data';
+
+import 'package:ap_common/ap_common.dart';
+import 'package:flutter/foundation.dart' show debugPrint, kDebugMode;
+import 'package:flutter/material.dart';
+import 'package:nsysu_ap/config/constants.dart';
+import 'package:nsysu_ap/utils/app_localizations.dart';
+import 'package:nsysu_ap/utils/enroll_certificate/enroll_certificate_cache.dart';
+import 'package:nsysu_crawler/nsysu_crawler.dart';
+import 'package:printing/printing.dart';
+
+typedef EnrollmentCertificateCredentialsProvider =
+    EnrollmentCertificateCredentials Function();
+typedef EnrollmentCertificateDownload =
+    Future<Uint8List> Function({
+      required String username,
+      required String password,
+    });
+typedef EnrollmentCertificateCacheReader =
+    Future<Uint8List?> Function({required String username});
+typedef EnrollmentCertificateCacheWriter =
+    Future<void> Function({required String username, required Uint8List bytes});
+typedef EnrollmentCertificatePdfExporter =
+    Future<bool> Function({required Uint8List bytes, required String fileName});
+typedef EnrollmentCertificatePdfViewBuilder =
+    Widget Function(BuildContext context, Uint8List bytes, String fileName);
+
+class EnrollmentCertificateCredentials {
+  const EnrollmentCertificateCredentials({
+    required this.username,
+    required this.password,
+  });
+
+  final String username;
+  final String password;
+}
+
+class EnrollCertificatePage extends StatefulWidget {
+  const EnrollCertificatePage({
+    super.key,
+    this.credentialsProvider,
+    this.downloadCertificate,
+    this.readCachedCertificate,
+    this.writeCachedCertificate,
+    this.supportDirectoryProvider,
+    this.exportPdf,
+    this.pdfViewBuilder,
+  });
+
+  final EnrollmentCertificateCredentialsProvider? credentialsProvider;
+  final EnrollmentCertificateDownload? downloadCertificate;
+  final EnrollmentCertificateCacheReader? readCachedCertificate;
+  final EnrollmentCertificateCacheWriter? writeCachedCertificate;
+  final SupportDirectoryProvider? supportDirectoryProvider;
+  final EnrollmentCertificatePdfExporter? exportPdf;
+  final EnrollmentCertificatePdfViewBuilder? pdfViewBuilder;
+
+  @override
+  State<EnrollCertificatePage> createState() => _EnrollCertificatePageState();
+}
+
+class _EnrollCertificatePageState extends State<EnrollCertificatePage> {
+  static const String _debugPrefix = '[EnrollCertificatePage]';
+
+  bool _isRunning = true;
+  bool _isFetching = false;
+  late String _status;
+  String _username = '';
+  String _password = '';
+  Uint8List? _pdfData;
+  late EnrollCertificateCache _cache;
+  EnrollmentCertificateHelper? _activeHelper;
+
+  @override
+  void initState() {
+    super.initState();
+    _status = app.enrollCertificate.loadingCached;
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      await _initialize();
+    });
+  }
+
+  @override
+  void dispose() {
+    final EnrollmentCertificateHelper? helper = _activeHelper;
+    _debugLog('event=dispose activeHelper=${helper != null}');
+    _activeHelper = null;
+    helper?.close();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(app.enrollCertificate.title),
+        actions: <Widget>[
+          if (_pdfData != null) ...<Widget>[
+            IconButton(
+              key: const ValueKey<String>('enroll-certificate-download'),
+              onPressed: _download,
+              tooltip: app.enrollCertificate.download,
+              icon: const Icon(Icons.download_rounded),
+            ),
+            TextButton.icon(
+              key: const ValueKey<String>('enroll-certificate-regenerate'),
+              onPressed: _isRunning ? null : _retrieve,
+              icon: const Icon(Icons.autorenew_rounded),
+              label: Text(app.enrollCertificate.regenerate),
+            ),
+          ],
+        ],
+      ),
+      body: _buildBody(),
+    );
+  }
+
+  Widget _buildBody() {
+    final Uint8List? pdf = _pdfData;
+    if (pdf != null && !_isRunning) {
+      final String fileName = app.enrollCertificate.fileName;
+      return KeyedSubtree(
+        key: const ValueKey<String>('enroll-certificate-pdf'),
+        child:
+            widget.pdfViewBuilder?.call(context, pdf, fileName) ??
+            HeroMode(
+              enabled: false,
+              child: PdfView(
+                state: PdfState.finish,
+                data: pdf,
+                fileName: fileName,
+              ),
+            ),
+      );
+    }
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            if (_isRunning)
+              const CircularProgressIndicator(
+                key: ValueKey<String>('enroll-certificate-progress'),
+              )
+            else
+              const Icon(Icons.info_outline_rounded, size: 36),
+            const SizedBox(height: 20),
+            Text(_status, textAlign: TextAlign.center),
+            if (!_isRunning) ...<Widget>[
+              const SizedBox(height: 20),
+              FilledButton.icon(
+                key: const ValueKey<String>('enroll-certificate-retry'),
+                onPressed: _retrieve,
+                icon: const Icon(Icons.refresh_rounded),
+                label: Text(app.enrollCertificate.retry),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _initialize() async {
+    final EnrollmentCertificateCredentials credentials =
+        widget.credentialsProvider?.call() ?? _loadCredentials();
+    _username = credentials.username.replaceAll(' ', '').trim().toUpperCase();
+    _password = credentials.password;
+    _debugLog(
+      'event=initialize usernamePresent=${_username.isNotEmpty} '
+      'passwordPresent=${_password.isNotEmpty}',
+    );
+
+    if (_username.isEmpty) {
+      _debugLog('event=initialize_blocked reason=missing_account');
+      if (!mounted) return;
+      setState(() {
+        _isRunning = false;
+        _status = app.enrollCertificate.missingAccount;
+      });
+      return;
+    }
+
+    _cache = EnrollCertificateCache(
+      username: _username,
+      supportDirectoryProvider: widget.supportDirectoryProvider,
+    );
+    try {
+      _debugLog('event=cache_read_start');
+      final Uint8List? cachedPdf = await _readCachedCertificate();
+      if (!mounted) return;
+      if (cachedPdf != null) {
+        _debugLog('event=cache_hit pdfBytes=${cachedPdf.length}');
+        setState(() {
+          _pdfData = cachedPdf;
+          _isRunning = false;
+          _status = '';
+        });
+        return;
+      }
+      _debugLog('event=cache_miss');
+    } on Exception catch (error) {
+      _debugLog('event=cache_read_failure sourceType=${error.runtimeType}');
+      // A cache read failure is treated as a miss; a fresh copy can still load.
+    }
+
+    await _retrieve();
+  }
+
+  EnrollmentCertificateCredentials _loadCredentials() {
+    String username = SelcrsHelper.instance.username.trim();
+    String password = SelcrsHelper.instance.password;
+    username = username.isNotEmpty
+        ? username
+        : PreferenceUtil.instance.getString(Constants.prefUsername, '').trim();
+    password = password.isNotEmpty
+        ? password
+        : PreferenceUtil.instance.getStringSecurity(Constants.prefPassword, '');
+    return EnrollmentCertificateCredentials(
+      username: username,
+      password: password,
+    );
+  }
+
+  Future<void> _retrieve() async {
+    if (!mounted || _isFetching) {
+      if (_isFetching) {
+        _debugLog('event=retrieve_ignored reason=already_running');
+      }
+      return;
+    }
+    if (_username.isEmpty || _password.isEmpty) {
+      _debugLog(
+        'event=retrieve_blocked reason=missing_credentials '
+        'usernamePresent=${_username.isNotEmpty} '
+        'passwordPresent=${_password.isNotEmpty}',
+      );
+      if (!mounted) return;
+      setState(() {
+        _isRunning = false;
+        _status = app.enrollCertificate.missingCredentials;
+      });
+      return;
+    }
+
+    final String mode = _pdfData == null ? 'initial' : 'regenerate';
+    _debugLog('event=retrieve_start mode=$mode');
+    _isFetching = true;
+    if (mounted) {
+      setState(() {
+        _isRunning = true;
+        _status = app.enrollCertificate.retrieving;
+      });
+    }
+
+    try {
+      final Uint8List pdf = await _fetchCertificate();
+      _debugLog('event=retrieve_download_complete pdfBytes=${pdf.length}');
+      if (!mounted) {
+        _debugLog('event=retrieve_cancelled reason=page_unmounted');
+        return;
+      }
+      bool cacheSaveFailed = false;
+      try {
+        await _writeCachedCertificate(pdf);
+        _debugLog('event=cache_write_complete pdfBytes=${pdf.length}');
+      } on FormatException catch (error) {
+        _debugLog(
+          'event=cache_write_failure sourceType=${error.runtimeType} '
+          'fatal=true',
+        );
+        rethrow;
+      } on Exception catch (error) {
+        _debugLog(
+          'event=cache_write_failure sourceType=${error.runtimeType} '
+          'fatal=false',
+        );
+        cacheSaveFailed = true;
+      }
+      if (!mounted) {
+        _debugLog('event=retrieve_cancelled reason=page_unmounted');
+        return;
+      }
+      setState(() {
+        _pdfData = pdf;
+        _isRunning = false;
+        _status = '';
+      });
+      _debugLog(
+        'event=retrieve_complete mode=$mode cacheSaved=${!cacheSaveFailed}',
+      );
+      if (cacheSaveFailed) {
+        _showMessage(app.enrollCertificate.saveFailed);
+      }
+    } on EnrollmentCertificateException catch (error) {
+      _debugLog(
+        'event=retrieve_failure kind=${error.kind.name} '
+        'status=${error.statusCode ?? 'none'}',
+      );
+      _handleRetrievalFailure(_messageFor(error.kind));
+    } catch (error) {
+      _debugLog(
+        'event=retrieve_failure kind=unexpected '
+        'sourceType=${error.runtimeType}',
+      );
+      _handleRetrievalFailure(app.enrollCertificate.requestFailed);
+    } finally {
+      _isFetching = false;
+      _debugLog('event=retrieve_end mode=$mode');
+    }
+  }
+
+  Future<Uint8List> _fetchCertificate() async {
+    final EnrollmentCertificateDownload? injectedDownload =
+        widget.downloadCertificate;
+    if (injectedDownload != null) {
+      _debugLog('event=fetch_transport kind=injected');
+      return injectedDownload(username: _username, password: _password);
+    }
+
+    _debugLog('event=fetch_transport kind=regweb');
+    final EnrollmentCertificateHelper helper = EnrollmentCertificateHelper();
+    _activeHelper = helper;
+    try {
+      return await helper.download(username: _username, password: _password);
+    } finally {
+      if (identical(_activeHelper, helper)) {
+        _activeHelper = null;
+        _debugLog('event=fetch_transport_close kind=regweb');
+        helper.close();
+      }
+    }
+  }
+
+  Future<Uint8List?> _readCachedCertificate() {
+    final EnrollmentCertificateCacheReader? reader =
+        widget.readCachedCertificate;
+    if (reader != null) {
+      return reader(username: _username);
+    }
+    return _cache.read();
+  }
+
+  Future<void> _writeCachedCertificate(Uint8List bytes) {
+    final EnrollmentCertificateCacheWriter? writer =
+        widget.writeCachedCertificate;
+    if (writer != null) {
+      return writer(username: _username, bytes: bytes);
+    }
+    return _cache.save(bytes);
+  }
+
+  String _messageFor(EnrollmentCertificateExceptionKind kind) {
+    return switch (kind) {
+      EnrollmentCertificateExceptionKind.credentials =>
+        app.enrollCertificate.missingCredentials,
+      EnrollmentCertificateExceptionKind.timeout =>
+        app.enrollCertificate.requestTimedOut,
+      EnrollmentCertificateExceptionKind.tooLarge ||
+      EnrollmentCertificateExceptionKind.invalidPdf =>
+        app.enrollCertificate.invalidResponse,
+      EnrollmentCertificateExceptionKind.http ||
+      EnrollmentCertificateExceptionKind.redirect ||
+      EnrollmentCertificateExceptionKind.cancelled ||
+      EnrollmentCertificateExceptionKind.network =>
+        app.enrollCertificate.requestFailed,
+    };
+  }
+
+  void _handleRetrievalFailure(String message) {
+    if (!mounted) return;
+    setState(() {
+      _isRunning = false;
+      _status = _pdfData == null ? message : '';
+    });
+    if (_pdfData != null) {
+      _showMessage(message);
+    }
+  }
+
+  Future<void> _download() async {
+    final Uint8List? pdf = _pdfData;
+    if (pdf == null) return;
+    _debugLog('event=export_start pdfBytes=${pdf.length}');
+    final String fileName = '${app.enrollCertificate.fileName}.pdf';
+    try {
+      final EnrollmentCertificatePdfExporter? exporter = widget.exportPdf;
+      final bool exported;
+      if (exporter != null) {
+        exported = await exporter(bytes: pdf, fileName: fileName);
+      } else {
+        exported = await Printing.sharePdf(bytes: pdf, filename: fileName);
+      }
+      _debugLog('event=export_complete success=$exported');
+      if (!exported && mounted) {
+        _showMessage(app.enrollCertificate.downloadFailed);
+      }
+    } catch (error) {
+      _debugLog('event=export_failure sourceType=${error.runtimeType}');
+      if (!mounted) return;
+      _showMessage(app.enrollCertificate.downloadFailed);
+    }
+  }
+
+  void _showMessage(String message) {
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  void _debugLog(String message) {
+    if (!kDebugMode) return;
+    debugPrint('$_debugPrefix $message');
+  }
+}

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -20,6 +20,7 @@ import 'package:nsysu_ap/pages/tuition_and_fees_page.dart';
 import 'package:nsysu_ap/pages/user_info_page.dart';
 import 'package:nsysu_ap/resources/image_assets.dart';
 import 'package:nsysu_ap/utils/app_localizations.dart';
+import 'package:nsysu_ap/utils/enroll_certificate/enroll_certificate_cache.dart';
 import 'package:nsysu_ap/utils/utils.dart';
 import 'package:nsysu_ap/widgets/share_data_widget.dart';
 import 'package:nsysu_crawler/nsysu_crawler.dart';
@@ -384,7 +385,8 @@ class HomePageState extends State<HomePage> {
           DrawerMenuItem(
             icon: Icons.picture_as_pdf_outlined,
             title: app.enrollCertificate.title,
-            onTap: () => _openPage(const EnrollCertificatePage()),
+            onTap: () =>
+                _openPage(const EnrollCertificatePage(), needLogin: true),
           ),
           DrawerMenuItem(
             icon: ApIcon.info,
@@ -423,6 +425,7 @@ class HomePageState extends State<HomePage> {
                   Constants.prefAutoLogin,
                   false,
                 );
+                await _clearEnrollmentCertificateCache();
                 SelcrsHelper.instance.logout();
                 GraduationHelper.instance.logout();
                 TuitionHelper.instance.logout();
@@ -444,6 +447,24 @@ class HomePageState extends State<HomePage> {
         ],
       ),
     );
+  }
+
+  Future<void> _clearEnrollmentCertificateCache() async {
+    // Read the in-memory username before SelcrsHelper.logout() clears it.
+    String username = SelcrsHelper.instance.username.trim();
+    username = username.isNotEmpty
+        ? username
+        : PreferenceUtil.instance.getString(Constants.prefUsername, '').trim();
+    if (username.isEmpty) return;
+
+    try {
+      await EnrollCertificateCache(username: username).clear();
+    } on Exception catch (error) {
+      debugPrint(
+        'Failed to clear enrollment certificate cache during logout: '
+        '${error.runtimeType}',
+      );
+    }
   }
 
   Widget _buildStudySection() {

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:nsysu_ap/config/constants.dart';
 import 'package:nsysu_ap/pages/bus/bus_list_page.dart';
+import 'package:nsysu_ap/pages/enroll_certificate/enroll_certificate_page.dart';
 import 'package:nsysu_ap/pages/graduation_report_page.dart';
 import 'package:nsysu_ap/pages/guide/school_map_page.dart';
 import 'package:nsysu_ap/pages/info/shcool_info_page.dart';
@@ -379,6 +380,11 @@ class HomePageState extends State<HomePage> {
             icon: ApIcon.monetizationOn,
             title: app.tuitionAndFees,
             onTap: () => _openPage(const TuitionAndFeesPage(), needLogin: true),
+          ),
+          DrawerMenuItem(
+            icon: Icons.picture_as_pdf_outlined,
+            title: app.enrollCertificate.title,
+            onTap: () => _openPage(const EnrollCertificatePage()),
           ),
           DrawerMenuItem(
             icon: ApIcon.info,

--- a/lib/utils/enroll_certificate/enroll_certificate_cache.dart
+++ b/lib/utils/enroll_certificate/enroll_certificate_cache.dart
@@ -1,0 +1,241 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:path_provider/path_provider.dart';
+
+typedef SupportDirectoryProvider = Future<Directory> Function();
+
+class EnrollCertificateCache {
+  EnrollCertificateCache({
+    required String username,
+    SupportDirectoryProvider? supportDirectoryProvider,
+  }) : _accountKey = sha256
+           .convert(utf8.encode(username.trim().toUpperCase()))
+           .toString()
+           .substring(0, 16),
+       _supportDirectoryProvider =
+           supportDirectoryProvider ?? getApplicationSupportDirectory;
+
+  static const int minimumPdfLength = 1024;
+  static const int maximumPdfLength = 10 * 1024 * 1024;
+
+  static const List<int> _pdfHeader = <int>[0x25, 0x50, 0x44, 0x46, 0x2d];
+  static const List<int> _pdfEof = <int>[0x25, 0x25, 0x45, 0x4f, 0x46];
+
+  final String _accountKey;
+  final SupportDirectoryProvider _supportDirectoryProvider;
+
+  Future<Uint8List?> read() async {
+    final File file = await _cacheFile();
+    final File temporaryFile = File('${file.path}.tmp');
+    final File backupFile = File('${file.path}.bak');
+
+    final Uint8List? cachedPdf = await _readValidPdf(file);
+    if (cachedPdf != null) {
+      // A committed cache always wins. Cleanup is intentionally best-effort:
+      // stale crash artifacts must never make a valid certificate unreadable.
+      await _deleteBestEffort(backupFile);
+      await _deleteBestEffort(temporaryFile);
+      return cachedPdf;
+    }
+    await _deleteBestEffort(file);
+
+    // A backup is the last committed value, so prefer it over a temporary
+    // replacement if both survived an interrupted save.
+    final Uint8List? backupPdf = await _readValidPdf(backupFile);
+    if (backupPdf != null) {
+      await _restoreArtifact(source: backupFile, destination: file);
+      await _deleteBestEffort(temporaryFile);
+      return backupPdf;
+    }
+    await _deleteBestEffort(backupFile);
+
+    final Uint8List? temporaryPdf = await _readValidPdf(temporaryFile);
+    if (temporaryPdf != null) {
+      await _restoreArtifact(source: temporaryFile, destination: file);
+      return temporaryPdf;
+    }
+    await _deleteBestEffort(temporaryFile);
+    return null;
+  }
+
+  Future<void> save(Uint8List bytes) async {
+    // Validate before touching any on-disk state so a bad response can never
+    // replace a previously cached certificate.
+    final Uint8List? pdf = extractPdf(bytes);
+    if (pdf == null) {
+      throw const FormatException('The certificate response is not a PDF.');
+    }
+
+    final File file = await _cacheFile(createDirectory: true);
+    final File temporaryFile = File('${file.path}.tmp');
+    final File backupFile = File('${file.path}.bak');
+
+    if (await temporaryFile.exists()) {
+      await temporaryFile.delete();
+    }
+    await temporaryFile.writeAsBytes(pdf, flush: true);
+
+    bool existingFileWasMoved = false;
+    try {
+      if (await backupFile.exists()) {
+        await backupFile.delete();
+      }
+      if (await file.exists()) {
+        await file.rename(backupFile.path);
+        existingFileWasMoved = true;
+      }
+
+      await temporaryFile.rename(file.path);
+    } catch (error, stackTrace) {
+      if (existingFileWasMoved &&
+          !await file.exists() &&
+          await backupFile.exists()) {
+        await backupFile.rename(file.path);
+      }
+      if (await temporaryFile.exists()) {
+        await temporaryFile.delete();
+      }
+      Error.throwWithStackTrace(error, stackTrace);
+    }
+
+    // The replacement is already complete. A stale backup is harmless and
+    // must not turn a successful, atomic replacement into an apparent error.
+    if (await backupFile.exists()) {
+      try {
+        await backupFile.delete();
+      } on FileSystemException {
+        // Best-effort cleanup; clear() also removes this account's backup.
+      }
+    }
+  }
+
+  Future<void> clear() async {
+    final File file = await _cacheFile();
+    for (final File artifact in <File>[
+      file,
+      File('${file.path}.tmp'),
+      File('${file.path}.bak'),
+    ]) {
+      if (await artifact.exists()) {
+        await artifact.delete();
+      }
+    }
+  }
+
+  static Uint8List? extractPdf(Uint8List bytes) {
+    if (bytes.length > maximumPdfLength) {
+      return null;
+    }
+
+    int start = 0;
+    while (start < bytes.length && _isAsciiWhitespace(bytes[start])) {
+      start++;
+    }
+    if (!_matchesAt(bytes, _pdfHeader, start)) {
+      return null;
+    }
+
+    final int eofStart = _lastIndexOf(bytes, _pdfEof);
+    if (eofStart < start) {
+      return null;
+    }
+    final int end = eofStart + _pdfEof.length;
+    final int pdfLength = end - start;
+    if (pdfLength < minimumPdfLength || pdfLength > maximumPdfLength) {
+      return null;
+    }
+
+    return Uint8List.fromList(bytes.sublist(start, end));
+  }
+
+  Future<File> _cacheFile({bool createDirectory = false}) async {
+    final Directory supportDirectory = await _supportDirectoryProvider();
+    final Directory directory = Directory(
+      '${supportDirectory.path}/enroll_certificates',
+    );
+    if (createDirectory) {
+      await directory.create(recursive: true);
+    }
+    return File('${directory.path}/enroll_certificate_$_accountKey.pdf');
+  }
+
+  static Future<Uint8List?> _readValidPdf(File file) async {
+    try {
+      final FileStat stat = await file.stat();
+      if (stat.type != FileSystemEntityType.file ||
+          stat.size < minimumPdfLength ||
+          stat.size > maximumPdfLength) {
+        return null;
+      }
+
+      // File length can change after stat(). Limit both the stream range and
+      // the in-memory buffer so a TOCTOU growth cannot allocate unboundedly.
+      final BytesBuilder builder = BytesBuilder(copy: false);
+      await for (final List<int> chunk in file.openRead(
+        0,
+        maximumPdfLength + 1,
+      )) {
+        if (chunk.length > maximumPdfLength - builder.length) {
+          return null;
+        }
+        builder.add(chunk);
+      }
+      return extractPdf(builder.takeBytes());
+    } on FileSystemException {
+      return null;
+    }
+  }
+
+  static Future<void> _restoreArtifact({
+    required File source,
+    required File destination,
+  }) async {
+    try {
+      if (await destination.exists()) {
+        await destination.delete();
+      }
+      await source.rename(destination.path);
+    } on FileSystemException {
+      // The validated source remains readable even if cleanup or promotion is
+      // denied. A later read can retry recovery without losing the cache.
+    }
+  }
+
+  static Future<void> _deleteBestEffort(File file) async {
+    try {
+      if (await file.exists()) {
+        await file.delete();
+      }
+    } on FileSystemException {
+      // Cleanup failure must not hide a valid cache or recovery artifact.
+    }
+  }
+
+  static bool _isAsciiWhitespace(int byte) {
+    return byte == 0x20 || (byte >= 0x09 && byte <= 0x0d);
+  }
+
+  static int _lastIndexOf(List<int> source, List<int> pattern) {
+    for (int i = source.length - pattern.length; i >= 0; i--) {
+      if (_matchesAt(source, pattern, i)) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  static bool _matchesAt(List<int> source, List<int> pattern, int offset) {
+    if (offset < 0 || offset + pattern.length > source.length) {
+      return false;
+    }
+    for (int i = 0; i < pattern.length; i++) {
+      if (source[offset + i] != pattern[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/lib/utils/enroll_certificate/enroll_certificate_cache.dart
+++ b/lib/utils/enroll_certificate/enroll_certificate_cache.dart
@@ -5,9 +5,20 @@ import 'dart:typed_data';
 import 'package:crypto/crypto.dart';
 import 'package:path_provider/path_provider.dart';
 
+/// Returns the directory where app-support files should be stored.
 typedef SupportDirectoryProvider = Future<Directory> Function();
 
+/// Account-scoped storage for the last valid enrollment certificate PDF.
+///
+/// The cache file name uses a short hash of the normalized username so multiple
+/// accounts on the same device do not read each other's certificate. Every
+/// write validates the PDF and commits through temporary/backup artifacts so a
+/// failed refresh cannot replace a previously usable document.
 class EnrollCertificateCache {
+  /// Creates a cache bound to [username].
+  ///
+  /// [supportDirectoryProvider] is injectable so tests can use a temporary
+  /// directory without touching the app support directory.
   EnrollCertificateCache({
     required String username,
     SupportDirectoryProvider? supportDirectoryProvider,
@@ -27,6 +38,11 @@ class EnrollCertificateCache {
   final String _accountKey;
   final SupportDirectoryProvider _supportDirectoryProvider;
 
+  /// Returns the current account's cached PDF, or `null` when no valid cache
+  /// exists.
+  ///
+  /// Invalid primary files are deleted, and valid `.bak` / `.tmp` recovery
+  /// artifacts are promoted back to the primary path when possible.
   Future<Uint8List?> read() async {
     final File file = await _cacheFile();
     final File temporaryFile = File('${file.path}.tmp');
@@ -61,6 +77,11 @@ class EnrollCertificateCache {
     return null;
   }
 
+  /// Saves [bytes] after extracting one bounded PDF payload.
+  ///
+  /// Throws [FormatException] before touching disk when the response is not a
+  /// valid PDF. I/O failures during replacement restore the previous cache when
+  /// possible, then rethrow the original error.
   Future<void> save(Uint8List bytes) async {
     // Validate before touching any on-disk state so a bad response can never
     // replace a previously cached certificate.
@@ -112,6 +133,8 @@ class EnrollCertificateCache {
     }
   }
 
+  /// Removes the current account's primary cache and pending replacement
+  /// artifacts.
   Future<void> clear() async {
     final File file = await _cacheFile();
     for (final File artifact in <File>[
@@ -125,6 +148,10 @@ class EnrollCertificateCache {
     }
   }
 
+  /// Extracts a single PDF from a RegWeb response.
+  ///
+  /// Only ASCII whitespace may surround the PDF. HTML error pages, arbitrary
+  /// prefixes, truncated files, and oversized payloads return `null`.
   static Uint8List? extractPdf(Uint8List bytes) {
     if (bytes.length > maximumPdfLength) {
       return null;

--- a/packages/nsysu_crawler/README.md
+++ b/packages/nsysu_crawler/README.md
@@ -17,13 +17,14 @@ second native client without dragging Flutter SDK dependencies along.
 import 'package:nsysu_crawler/nsysu_crawler.dart';
 ```
 
-### 4 個 helper（皆為 singleton，透過 `.instance` 取用）
+### 5 個 helper
 
 | Helper | 主要方法 | 是否需登入 |
 |---|---|---|
 | `SelcrsHelper` | `login`, `getUserInfo`, `getCourseSemesterData`, `getCourseData`, `getScoreSemesterData`, `getScoreData`, `changeMail`, `getUsername`,`getPreScoreData` | ✅ |
 | `GraduationHelper` | `login`, `getGraduationReport` | ✅（獨立 session）|
 | `TuitionHelper` | `login`, `getData`, `downloadFdf` | ✅（明文密碼，學校系統限制）|
+| `EnrollmentCertificateHelper` | `download` | ✅（RegWeb 獨立 session；每次下載建立 helper 後 close）|
 | `BusHelper` | `getBusInfoList(languageCode:)`, `getBusTime(languageCode:, busInfo:)` | ❌ |
 
 ### 2 個抽象介面（NoOp 預設，host app 注入真實實作）
@@ -78,7 +79,7 @@ void bootstrapCrawler() {
 
 | 層 | 命令 | 跑哪些 | 何時跑 |
 |---|---|---|---|
-| Hermetic | `dart test` | abstractions、codec、model JSON、`redact()`、`currentAcademicSemester()` | 每次 `dart test` |
+| Hermetic | `dart test` | abstractions、codec、model JSON、`redact()`、`currentAcademicSemester()`、在學證明 RegWeb redirect / PDF validation | 每次 `dart test` |
 | Live (anonymous) | `dart test -P live-anonymous -r expanded` | 3 個 health check probe + bus（不需 creds）| 本機 debug bus、CI 排程 |
 | Live (authenticated) | `NSYSU_USER=… NSYSU_PASS=… dart test -P live -r expanded` | selcrs + graduation + tuition 全套 | 本機需要打真站 / CI 排程 |
 
@@ -117,7 +118,7 @@ nsysu_crawler/
 │   ├── nsysu_crawler.dart                # 公開 barrel
 │   └── src/
 │       ├── abstractions/                 # CrashReporter / AnalyticsLogger 介面
-│       ├── helpers/                      # 4 個 helper（dio + cookie + 解析串接）
+│       ├── helpers/                      # 5 個 helper（dio + cookie + 解析串接）
 │       ├── models/                       # Bus / Score / Tuition / Graduation 等
 │       ├── parsers/                      # pure HTML parser（fixture-testable）
 │       └── utils/

--- a/packages/nsysu_crawler/docs/endpoint-catalog.md
+++ b/packages/nsysu_crawler/docs/endpoint-catalog.md
@@ -86,7 +86,25 @@ PDF 序號從 `<a onclick="javascript:window.location.href='...'">` 解出。
 
 ---
 
-## 4. 校車 — `ibus.nsysu.edu.tw` + GitHub Pages CDN
+## 4. 在學證明 — `regweb.nsysu.edu.tw/webreg/`
+
+| Path | Method | Body | Encoding | Sentinel |
+|---|---|---|---|---|
+| `/webreg/wregloginchk2.asp` | POST | `ID=<學號>`, `passwd=<明文>` | response bytes | 2xx after same-host redirect chain |
+| `/webreg/WRegMain3.asp?act=71&out=print/enrollcert.asp` | GET | — | response bytes | 2xx |
+| `/webreg/print/enrollcert.asp` | POST | `ssn1=idno`, `idno=<學號>` | bytes (PDF) | `%PDF-` header + `%%EOF` trailer |
+
+實作：`EnrollmentCertificateHelper.download()`。RegWeb 和 `SelcrsHelper` / `GraduationHelper` / `TuitionHelper` 不共用 cookie jar；Flutter app 每次提取時建立新的 helper，完成、失敗或離開頁面時都會 `close()`。
+
+安全邊界：
+
+- redirect 只允許留在 `https://regweb.nsysu.edu.tw:443/webreg/`，避免把登入狀態或表單送到站外。
+- response body 上限 10 MiB；過大的 `Content-Length` 或 stream 都會被取消。
+- PDF cache 在 app 端依帳號 hash 分檔，登出時會清除該帳號的 `.pdf` / `.tmp` / `.bak`。
+
+---
+
+## 5. 校車 — `ibus.nsysu.edu.tw` + GitHub Pages CDN
 
 | Path | Method | Body | Encoding | Helper |
 |---|---|---|---|---|
@@ -99,7 +117,7 @@ URL query 後綴 `?<millisecondsSinceEpoch>` 是用來破 CDN cache，不是 aut
 
 ---
 
-## 5. 其它（已知但目前未實作）
+## 6. 其它（已知但目前未實作）
 
 這些 endpoint 在 root README 的爬蟲清單裡有列、但尚未抽 helper：
 

--- a/packages/nsysu_crawler/lib/nsysu_crawler.dart
+++ b/packages/nsysu_crawler/lib/nsysu_crawler.dart
@@ -2,6 +2,7 @@ export 'src/abstractions/analytics_logger.dart';
 export 'src/abstractions/crash_reporter.dart';
 export 'src/build_mode.dart';
 export 'src/helpers/bus_helper.dart';
+export 'src/helpers/enrollment_certificate_helper.dart';
 export 'src/helpers/graduation_helper.dart';
 export 'src/helpers/selcrs_helper.dart';
 export 'src/helpers/tuition_helper.dart';

--- a/packages/nsysu_crawler/lib/src/helpers/enrollment_certificate_helper.dart
+++ b/packages/nsysu_crawler/lib/src/helpers/enrollment_certificate_helper.dart
@@ -9,17 +9,35 @@ import 'package:dio/io.dart';
 import 'package:dio_cookie_manager/dio_cookie_manager.dart';
 import 'package:nsysu_crawler/src/build_mode.dart';
 
+/// Categories of recoverable enrollment-certificate failures.
 enum EnrollmentCertificateExceptionKind {
+  /// The caller did not provide a usable username/password, or RegWeb rejected
+  /// them at the login step.
   credentials,
+
+  /// A request exceeded the configured RegWeb timeout.
   timeout,
+
+  /// RegWeb returned a non-success status outside the login credential case.
   http,
+
+  /// A redirect was missing, malformed, excessive, or outside the allowed host.
   redirect,
+
+  /// RegWeb declared or streamed a response larger than the safety limit.
   tooLarge,
+
+  /// The final response was not a bounded PDF payload.
   invalidPdf,
+
+  /// The helper was closed or the underlying Dio request was cancelled.
   cancelled,
+
+  /// The request failed before a trusted HTTP response was available.
   network,
 }
 
+/// Typed failure returned by [EnrollmentCertificateHelper].
 class EnrollmentCertificateException implements Exception {
   const EnrollmentCertificateException(
     this.kind,
@@ -28,9 +46,16 @@ class EnrollmentCertificateException implements Exception {
     this.cause,
   });
 
+  /// Machine-readable category used by app UI to choose a user message.
   final EnrollmentCertificateExceptionKind kind;
+
+  /// Developer-facing failure summary.
   final String message;
+
+  /// HTTP status attached to the failure, when one was available.
   final int? statusCode;
+
+  /// Original transport/parser error, when this exception wraps one.
   final Object? cause;
 
   @override
@@ -46,6 +71,11 @@ class EnrollmentCertificateException implements Exception {
 /// requests in that one session. Redirects are followed manually so cookies
 /// are retained without allowing RegWeb to redirect credentials elsewhere.
 class EnrollmentCertificateHelper {
+  /// Creates an isolated RegWeb client.
+  ///
+  /// Pass [dio] and [cookieJar] only in tests. Production callers should create
+  /// a fresh helper per download and call [close] when the page is disposed or
+  /// the request finishes.
   EnrollmentCertificateHelper({Dio? dio, CookieJar? cookieJar})
     : _dio = dio ?? _createProductionDio(),
       _cookieJar = cookieJar ?? CookieJar() {
@@ -107,6 +137,11 @@ class EnrollmentCertificateHelper {
       ..headers[HttpHeaders.userAgentHeader] = _userAgent;
   }
 
+  /// Logs in to RegWeb, enters the enrollment-certificate context, and returns
+  /// the generated PDF bytes.
+  ///
+  /// The method does not persist credentials or cache the PDF. Callers are
+  /// responsible for storage and for closing this helper after use.
   Future<Uint8List> download({
     required String username,
     required String password,
@@ -686,6 +721,7 @@ class EnrollmentCertificateHelper {
     }
   }
 
+  /// Cancels active requests/readers and closes the Dio client.
   void close() {
     if (_isClosed) return;
     _debugLog(

--- a/packages/nsysu_crawler/lib/src/helpers/enrollment_certificate_helper.dart
+++ b/packages/nsysu_crawler/lib/src/helpers/enrollment_certificate_helper.dart
@@ -1,0 +1,827 @@
+import 'dart:async';
+import 'dart:developer' as developer;
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:cookie_jar/cookie_jar.dart';
+import 'package:dio/dio.dart';
+import 'package:dio/io.dart';
+import 'package:dio_cookie_manager/dio_cookie_manager.dart';
+import 'package:nsysu_crawler/src/build_mode.dart';
+
+enum EnrollmentCertificateExceptionKind {
+  credentials,
+  timeout,
+  http,
+  redirect,
+  tooLarge,
+  invalidPdf,
+  cancelled,
+  network,
+}
+
+class EnrollmentCertificateException implements Exception {
+  const EnrollmentCertificateException(
+    this.kind,
+    this.message, {
+    this.statusCode,
+    this.cause,
+  });
+
+  final EnrollmentCertificateExceptionKind kind;
+  final String message;
+  final int? statusCode;
+  final Object? cause;
+
+  @override
+  String toString() {
+    final String status = statusCode == null ? '' : ' ($statusCode)';
+    return 'EnrollmentCertificateException.${kind.name}$status: $message';
+  }
+}
+
+/// Downloads the currently authenticated student's enrollment certificate.
+///
+/// Every helper owns an independent cookie jar and keeps all three RegWeb
+/// requests in that one session. Redirects are followed manually so cookies
+/// are retained without allowing RegWeb to redirect credentials elsewhere.
+class EnrollmentCertificateHelper {
+  EnrollmentCertificateHelper({Dio? dio, CookieJar? cookieJar})
+    : _dio = dio ?? _createProductionDio(),
+      _cookieJar = cookieJar ?? CookieJar() {
+    _configureDio();
+    _dio.interceptors.add(CookieManager(_cookieJar));
+  }
+
+  static final Uri _loginUri = Uri.parse(
+    'https://regweb.nsysu.edu.tw/webreg/wregloginchk2.asp',
+  );
+  static final Uri _contextUri = Uri.parse(
+    'https://regweb.nsysu.edu.tw/webreg/'
+    'WRegMain3.asp?act=71&out=print/enrollcert.asp',
+  );
+  static final Uri _certificateUri = Uri.parse(
+    'https://regweb.nsysu.edu.tw/webreg/print/enrollcert.asp',
+  );
+  static const String _mainReferer =
+      'https://regweb.nsysu.edu.tw/webreg/WRegMain3.asp';
+  static const String _allowedHost = 'regweb.nsysu.edu.tw';
+  static const String _allowedPathPrefix = '/webreg/';
+  static const String _userAgent =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
+      'AppleWebKit/537.36 Chrome/138 Safari/537.36';
+  static const Duration _requestTimeout = Duration(seconds: 30);
+  static const int _maxResponseBytes = 10 * 1024 * 1024;
+  static const int _minimumPdfBytes = 1024;
+  static const int _maxRedirects = 5;
+  static const String _debugLogName = 'nsysu_crawler.enrollment_certificate';
+
+  final Dio _dio;
+  final CookieJar _cookieJar;
+  final Set<CancelToken> _activeCancelTokens = <CancelToken>{};
+  final Set<_ResponseStreamReader> _activeReaders = <_ResponseStreamReader>{};
+  bool _isClosed = false;
+
+  static Dio _createProductionDio() {
+    final Dio dio = Dio();
+    dio.httpClientAdapter = IOHttpClientAdapter(
+      createHttpClient: () {
+        // The app has historically installed an Android-wide HttpOverride.
+        // Resetting this callback keeps RegWeb on normal platform TLS checks.
+        final HttpClient client = HttpClient();
+        client.badCertificateCallback = null;
+        return client;
+      },
+    );
+    return dio;
+  }
+
+  void _configureDio() {
+    _dio.options
+      ..connectTimeout = _requestTimeout
+      ..sendTimeout = _requestTimeout
+      ..receiveTimeout = _requestTimeout
+      ..followRedirects = false
+      ..responseType = ResponseType.stream
+      ..validateStatus = ((int? status) => status != null)
+      ..headers[HttpHeaders.userAgentHeader] = _userAgent;
+  }
+
+  Future<Uint8List> download({
+    required String username,
+    required String password,
+  }) async {
+    if (_isClosed) {
+      _debugLog('event=download_rejected reason=helper_closed');
+      throw const EnrollmentCertificateException(
+        EnrollmentCertificateExceptionKind.cancelled,
+        'The enrollment certificate session is closed.',
+      );
+    }
+
+    final String normalizedUsername = username.trim();
+    if (normalizedUsername.isEmpty || password.trim().isEmpty) {
+      _debugLog(
+        'event=download_rejected reason=missing_credentials '
+        'usernamePresent=${normalizedUsername.isNotEmpty} '
+        'passwordPresent=${password.trim().isNotEmpty}',
+      );
+      throw const EnrollmentCertificateException(
+        EnrollmentCertificateExceptionKind.credentials,
+        'A non-empty username and password are required.',
+      );
+    }
+
+    _debugLog('event=download_start');
+    try {
+      final _BufferedResponse loginResponse = await _request(
+        stage: 'login',
+        method: 'POST',
+        uri: _loginUri,
+        form: <String, String>{'ID': normalizedUsername, 'passwd': password},
+      );
+      _requireSuccess(loginResponse, credentialsOnUnauthorized: true);
+      _debugLog(
+        'event=stage_complete stage=login status=${loginResponse.statusCode} '
+        'responseBytes=${loginResponse.bytes.length}',
+      );
+
+      final _BufferedResponse contextResponse = await _request(
+        stage: 'context',
+        method: 'GET',
+        uri: _contextUri,
+        referer: _mainReferer,
+      );
+      _requireSuccess(contextResponse);
+      _debugLog(
+        'event=stage_complete stage=context '
+        'status=${contextResponse.statusCode} '
+        'responseBytes=${contextResponse.bytes.length}',
+      );
+
+      final _BufferedResponse certificateResponse = await _request(
+        stage: 'certificate',
+        method: 'POST',
+        uri: _certificateUri,
+        referer: _mainReferer,
+        form: <String, String>{'ssn1': 'idno', 'idno': normalizedUsername},
+      );
+      _requireSuccess(certificateResponse);
+      _debugLog(
+        'event=stage_complete stage=certificate '
+        'status=${certificateResponse.statusCode} '
+        'responseBytes=${certificateResponse.bytes.length}',
+      );
+      final Uint8List pdf = _normalizePdf(certificateResponse.bytes);
+      _debugLog('event=download_complete pdfBytes=${pdf.length}');
+      return pdf;
+    } on EnrollmentCertificateException catch (error) {
+      _debugLog(
+        'event=download_failure kind=${error.kind.name} '
+        'status=${_debugStatus(error.statusCode)}',
+      );
+      rethrow;
+    } on DioException catch (error) {
+      final EnrollmentCertificateException mapped = _fromDioException(error);
+      _debugLog(
+        'event=download_failure kind=${mapped.kind.name} '
+        'status=${_debugStatus(mapped.statusCode)} '
+        'transport=${error.type.name}',
+      );
+      throw mapped;
+    } on TimeoutException catch (error) {
+      final EnrollmentCertificateException mapped =
+          EnrollmentCertificateException(
+            EnrollmentCertificateExceptionKind.timeout,
+            'The RegWeb request timed out.',
+            cause: error,
+          );
+      _debugLog('event=download_failure kind=${mapped.kind.name} status=none');
+      throw mapped;
+    } on SocketException catch (error) {
+      final EnrollmentCertificateException mapped =
+          EnrollmentCertificateException(
+            EnrollmentCertificateExceptionKind.network,
+            'The RegWeb request could not reach the server.',
+            cause: error,
+          );
+      _debugLog(
+        'event=download_failure kind=${mapped.kind.name} status=none '
+        'sourceType=${error.runtimeType}',
+      );
+      throw mapped;
+    } on Exception catch (error) {
+      final EnrollmentCertificateException mapped =
+          EnrollmentCertificateException(
+            EnrollmentCertificateExceptionKind.network,
+            'The RegWeb request failed.',
+            cause: error,
+          );
+      _debugLog(
+        'event=download_failure kind=${mapped.kind.name} status=none '
+        'sourceType=${error.runtimeType}',
+      );
+      throw mapped;
+    }
+  }
+
+  Future<_BufferedResponse> _request({
+    required String stage,
+    required String method,
+    required Uri uri,
+    Map<String, String>? form,
+    String? referer,
+  }) async {
+    String currentMethod = method;
+    Uri currentUri = uri;
+    Map<String, String>? currentForm = form;
+    int redirectCount = 0;
+
+    while (true) {
+      _requireAllowedUri(currentUri);
+      _debugLog(
+        'event=request_start stage=$stage method=$currentMethod '
+        'redirectHop=$redirectCount',
+      );
+      final Map<String, Object> headers = <String, Object>{
+        if (referer != null) HttpHeaders.refererHeader: referer,
+      };
+      final CancelToken cancelToken = CancelToken();
+      _activeCancelTokens.add(cancelToken);
+      final Response<ResponseBody> response;
+      final Uint8List bytes;
+      try {
+        response = await _dio.requestUri<ResponseBody>(
+          currentUri,
+          data: currentForm,
+          cancelToken: cancelToken,
+          options: Options(
+            method: currentMethod,
+            headers: headers,
+            contentType: currentForm == null
+                ? null
+                : Headers.formUrlEncodedContentType,
+            responseType: ResponseType.stream,
+            followRedirects: false,
+            validateStatus: (int? status) => status != null,
+            sendTimeout: _requestTimeout,
+            receiveTimeout: _requestTimeout,
+          ),
+        );
+        _debugLog(
+          'event=response_headers stage=$stage '
+          'status=${_debugStatus(response.statusCode)} '
+          'contentType=${_debugContentType(response.headers)} '
+          'declaredBytes=${_debugDeclaredLength(response.headers)}',
+        );
+        bytes = await _readBounded(
+          response,
+          stage: stage,
+          cancelToken: cancelToken,
+        );
+      } on DioException catch (error) {
+        _debugLog(
+          'event=request_transport_failure stage=$stage '
+          'transport=${error.type.name} '
+          'status=${_debugStatus(error.response?.statusCode)}',
+        );
+        rethrow;
+      } on EnrollmentCertificateException catch (error) {
+        _debugLog(
+          'event=request_body_failure stage=$stage kind=${error.kind.name} '
+          'status=${_debugStatus(error.statusCode)}',
+        );
+        rethrow;
+      } finally {
+        _activeCancelTokens.remove(cancelToken);
+      }
+      final int statusCode = response.statusCode ?? 0;
+      _debugLog(
+        'event=response_body_complete stage=$stage status=$statusCode '
+        'responseBytes=${bytes.length}',
+      );
+
+      if (!_isRedirectStatus(statusCode)) {
+        if (statusCode >= 300 && statusCode < 400) {
+          _debugLog(
+            'event=redirect_rejected stage=$stage '
+            'reason=unsupported_status status=$statusCode',
+          );
+          throw EnrollmentCertificateException(
+            EnrollmentCertificateExceptionKind.redirect,
+            'RegWeb returned an unsupported redirect status.',
+            statusCode: statusCode,
+          );
+        }
+        return _BufferedResponse(statusCode, bytes);
+      }
+
+      if (redirectCount >= _maxRedirects) {
+        _debugLog(
+          'event=redirect_rejected stage=$stage reason=limit_exceeded '
+          'status=$statusCode redirectHop=$redirectCount',
+        );
+        throw EnrollmentCertificateException(
+          EnrollmentCertificateExceptionKind.redirect,
+          'RegWeb exceeded the $_maxRedirects redirect limit.',
+          statusCode: statusCode,
+        );
+      }
+      final String? location = response.headers.value(
+        HttpHeaders.locationHeader,
+      );
+      if (location == null || location.trim().isEmpty) {
+        _debugLog(
+          'event=redirect_rejected stage=$stage reason=missing_location '
+          'status=$statusCode redirectHop=$redirectCount',
+        );
+        throw EnrollmentCertificateException(
+          EnrollmentCertificateExceptionKind.redirect,
+          'RegWeb returned a redirect without a Location header.',
+          statusCode: statusCode,
+        );
+      }
+
+      final Uri nextUri;
+      try {
+        nextUri = currentUri.resolve(location.trim());
+      } on FormatException catch (error) {
+        _debugLog(
+          'event=redirect_rejected stage=$stage reason=invalid_location '
+          'status=$statusCode redirectHop=$redirectCount',
+        );
+        throw EnrollmentCertificateException(
+          EnrollmentCertificateExceptionKind.redirect,
+          'RegWeb returned an invalid redirect target.',
+          statusCode: statusCode,
+          cause: error,
+        );
+      }
+      try {
+        _requireAllowedUri(nextUri, statusCode: statusCode);
+      } on EnrollmentCertificateException {
+        _debugLog(
+          'event=redirect_rejected stage=$stage reason=target_not_allowed '
+          'status=$statusCode redirectHop=$redirectCount',
+        );
+        rethrow;
+      }
+
+      final String previousMethod = currentMethod;
+      if (statusCode == 303 ||
+          ((statusCode == 301 || statusCode == 302) &&
+              currentMethod == 'POST')) {
+        currentMethod = 'GET';
+        currentForm = null;
+      }
+      currentUri = nextUri;
+      redirectCount += 1;
+      _debugLog(
+        'event=redirect_follow stage=$stage status=$statusCode '
+        'redirectHop=$redirectCount method=$currentMethod '
+        'methodChanged=${previousMethod != currentMethod}',
+      );
+    }
+  }
+
+  Future<Uint8List> _readBounded(
+    Response<ResponseBody> response, {
+    required String stage,
+    required CancelToken cancelToken,
+  }) async {
+    final ResponseBody? responseBody = response.data;
+    if (responseBody == null) {
+      if (_hasOversizedDeclaredLength(response)) {
+        _debugLog(
+          'event=response_rejected stage=$stage '
+          'reason=declared_size_exceeded '
+          'declaredBytes=${_debugDeclaredLength(response.headers)}',
+        );
+        throw const EnrollmentCertificateException(
+          EnrollmentCertificateExceptionKind.tooLarge,
+          'A RegWeb response exceeded the 10 MiB safety limit.',
+        );
+      }
+      _debugLog('event=response_body_missing stage=$stage');
+      return Uint8List(0);
+    }
+
+    final _ResponseStreamReader reader = _ResponseStreamReader(
+      responseBody.stream,
+      maxBytes: _maxResponseBytes,
+    );
+    _activeReaders.add(reader);
+    reader.startPaused();
+    try {
+      if (_isClosed) {
+        _debugLog('event=response_cancelled stage=$stage reason=helper_closed');
+        await _cancelTransport(cancelToken);
+        await reader.dispose();
+        throw const EnrollmentCertificateException(
+          EnrollmentCertificateExceptionKind.cancelled,
+          'The enrollment certificate session is closed.',
+        );
+      }
+      if (_hasOversizedDeclaredLength(response)) {
+        _debugLog(
+          'event=response_rejected stage=$stage '
+          'reason=declared_size_exceeded '
+          'declaredBytes=${_debugDeclaredLength(response.headers)}',
+        );
+        await _cancelTransport(cancelToken);
+        await reader.dispose();
+        throw const EnrollmentCertificateException(
+          EnrollmentCertificateExceptionKind.tooLarge,
+          'A RegWeb response exceeded the 10 MiB safety limit.',
+        );
+      }
+      reader.resume();
+      try {
+        return await reader.result;
+      } on EnrollmentCertificateException catch (error) {
+        if (error.kind == EnrollmentCertificateExceptionKind.tooLarge) {
+          _debugLog(
+            'event=response_rejected stage=$stage '
+            'reason=stream_size_exceeded '
+            'receivedBytes=${reader.receivedBytes}',
+          );
+          await _cancelTransport(cancelToken, reason: error);
+        }
+        rethrow;
+      }
+    } finally {
+      _activeReaders.remove(reader);
+      await reader.dispose();
+    }
+  }
+
+  static bool _hasOversizedDeclaredLength(Response<ResponseBody> response) {
+    final List<String>? declaredLengths =
+        response.headers[Headers.contentLengthHeader];
+    if (declaredLengths == null) return false;
+    for (final String rawValue in declaredLengths) {
+      for (final String value in rawValue.split(',')) {
+        final int? declaredLength = int.tryParse(value.trim());
+        if (declaredLength != null && declaredLength > _maxResponseBytes) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  static String _debugDeclaredLength(Headers headers) {
+    final List<String>? rawValues = headers[Headers.contentLengthHeader];
+    if (rawValues == null) return 'none';
+    for (final String rawValue in rawValues) {
+      for (final String value in rawValue.split(',')) {
+        final int? parsed = int.tryParse(value.trim());
+        if (parsed != null) return parsed.toString();
+      }
+    }
+    return 'invalid';
+  }
+
+  static String _debugContentType(Headers headers) {
+    final List<String>? values = headers[HttpHeaders.contentTypeHeader];
+    if (values == null || values.isEmpty) return 'none';
+    final String mediaType = values.first.split(';').first.trim().toLowerCase();
+    return switch (mediaType) {
+      'application/pdf' => 'application/pdf',
+      'text/html' => 'text/html',
+      'text/plain' => 'text/plain',
+      'application/octet-stream' => 'application/octet-stream',
+      _ => 'other',
+    };
+  }
+
+  static String _debugStatus(int? statusCode) {
+    return statusCode?.toString() ?? 'none';
+  }
+
+  static void _debugLog(String message) {
+    if (!kCrawlerDebugMode) return;
+    developer.log(message, name: _debugLogName);
+  }
+
+  static Future<void> _cancelTransport(
+    CancelToken cancelToken, {
+    Object? reason,
+  }) async {
+    if (!cancelToken.isCancelled) {
+      cancelToken.cancel(reason ?? 'Enrollment certificate response rejected');
+    }
+    // Dio's public cancellation hook closes the underlying ResponseBody and
+    // cancels its source subscription in a microtask.
+    await Future<void>.delayed(Duration.zero);
+  }
+
+  static bool _isRedirectStatus(int statusCode) {
+    return statusCode == 301 ||
+        statusCode == 302 ||
+        statusCode == 303 ||
+        statusCode == 307 ||
+        statusCode == 308;
+  }
+
+  static void _requireAllowedUri(Uri uri, {int? statusCode}) {
+    final bool hasTraversal = uri.pathSegments.any((String segment) {
+      final String decoded;
+      try {
+        decoded = Uri.decodeComponent(segment);
+      } on FormatException {
+        return true;
+      }
+      return decoded == '..' || decoded.contains('/') || decoded.contains(r'\');
+    });
+    final bool allowed =
+        uri.scheme == 'https' &&
+        uri.host == _allowedHost &&
+        uri.userInfo.isEmpty &&
+        uri.port == 443 &&
+        uri.path.startsWith(_allowedPathPrefix) &&
+        !hasTraversal;
+    if (!allowed) {
+      throw EnrollmentCertificateException(
+        EnrollmentCertificateExceptionKind.redirect,
+        'RegWeb attempted to leave its allowed HTTPS path.',
+        statusCode: statusCode,
+      );
+    }
+  }
+
+  static void _requireSuccess(
+    _BufferedResponse response, {
+    bool credentialsOnUnauthorized = false,
+  }) {
+    if (response.statusCode >= 200 && response.statusCode < 300) return;
+    if (credentialsOnUnauthorized &&
+        (response.statusCode == 401 || response.statusCode == 403)) {
+      throw EnrollmentCertificateException(
+        EnrollmentCertificateExceptionKind.credentials,
+        'RegWeb rejected the supplied credentials.',
+        statusCode: response.statusCode,
+      );
+    }
+    throw EnrollmentCertificateException(
+      EnrollmentCertificateExceptionKind.http,
+      'RegWeb returned an unsuccessful HTTP status.',
+      statusCode: response.statusCode,
+    );
+  }
+
+  static Uint8List _normalizePdf(Uint8List bytes) {
+    _debugLog('event=pdf_validation_start responseBytes=${bytes.length}');
+    int start = 0;
+    while (start < bytes.length && _isAsciiWhitespace(bytes[start])) {
+      start += 1;
+    }
+
+    const List<int> pdfHeader = <int>[0x25, 0x50, 0x44, 0x46, 0x2D];
+    if (!_matchesAt(bytes, start, pdfHeader)) {
+      _debugLog(
+        'event=pdf_validation_failure reason=missing_header '
+        'responseBytes=${bytes.length} leadingWhitespaceBytes=$start',
+      );
+      throw const EnrollmentCertificateException(
+        EnrollmentCertificateExceptionKind.invalidPdf,
+        'RegWeb returned a response without a PDF signature.',
+      );
+    }
+
+    const List<int> eofMarker = <int>[0x25, 0x25, 0x45, 0x4F, 0x46];
+    final int eofStart = _lastIndexOf(bytes, eofMarker);
+    if (eofStart < start) {
+      _debugLog(
+        'event=pdf_validation_failure reason=missing_eof '
+        'responseBytes=${bytes.length} leadingWhitespaceBytes=$start',
+      );
+      throw const EnrollmentCertificateException(
+        EnrollmentCertificateExceptionKind.invalidPdf,
+        'RegWeb returned an incomplete PDF response.',
+      );
+    }
+    final int end = eofStart + eofMarker.length;
+    for (int index = end; index < bytes.length; index += 1) {
+      if (!_isAsciiWhitespace(bytes[index])) {
+        _debugLog(
+          'event=pdf_validation_failure reason=trailing_data '
+          'responseBytes=${bytes.length} trailingOffset=$index',
+        );
+        throw const EnrollmentCertificateException(
+          EnrollmentCertificateExceptionKind.invalidPdf,
+          'RegWeb returned unexpected data after the PDF trailer.',
+        );
+      }
+    }
+    if (end - start < _minimumPdfBytes) {
+      _debugLog(
+        'event=pdf_validation_failure reason=too_short '
+        'pdfBytes=${end - start} minimumBytes=$_minimumPdfBytes',
+      );
+      throw const EnrollmentCertificateException(
+        EnrollmentCertificateExceptionKind.invalidPdf,
+        'RegWeb returned a PDF response that was unexpectedly short.',
+      );
+    }
+
+    final Uint8List pdf = Uint8List.fromList(bytes.sublist(start, end));
+    _debugLog(
+      'event=pdf_validation_complete pdfBytes=${pdf.length} '
+      'leadingWhitespaceBytes=$start trailingWhitespaceBytes=${bytes.length - end}',
+    );
+    return pdf;
+  }
+
+  static bool _matchesAt(Uint8List bytes, int index, List<int> pattern) {
+    if (index < 0 || index + pattern.length > bytes.length) return false;
+    for (int offset = 0; offset < pattern.length; offset += 1) {
+      if (bytes[index + offset] != pattern[offset]) return false;
+    }
+    return true;
+  }
+
+  static int _lastIndexOf(Uint8List bytes, List<int> pattern) {
+    for (int index = bytes.length - pattern.length; index >= 0; index -= 1) {
+      if (_matchesAt(bytes, index, pattern)) return index;
+    }
+    return -1;
+  }
+
+  static bool _isAsciiWhitespace(int byte) {
+    return byte == 0x20 || (byte >= 0x09 && byte <= 0x0D);
+  }
+
+  static EnrollmentCertificateException _fromDioException(DioException error) {
+    switch (error.type) {
+      case DioExceptionType.connectionTimeout:
+      case DioExceptionType.sendTimeout:
+      case DioExceptionType.receiveTimeout:
+        return EnrollmentCertificateException(
+          EnrollmentCertificateExceptionKind.timeout,
+          'The RegWeb request timed out.',
+          cause: error,
+        );
+      case DioExceptionType.cancel:
+        return EnrollmentCertificateException(
+          EnrollmentCertificateExceptionKind.cancelled,
+          'The RegWeb request was cancelled.',
+          cause: error,
+        );
+      case DioExceptionType.badResponse:
+        return EnrollmentCertificateException(
+          EnrollmentCertificateExceptionKind.http,
+          'RegWeb returned an unsuccessful HTTP status.',
+          statusCode: error.response?.statusCode,
+          cause: error,
+        );
+      case DioExceptionType.badCertificate:
+      case DioExceptionType.connectionError:
+      case DioExceptionType.unknown:
+        return EnrollmentCertificateException(
+          EnrollmentCertificateExceptionKind.network,
+          'The RegWeb request could not reach the server securely.',
+          cause: error,
+        );
+    }
+  }
+
+  void close() {
+    if (_isClosed) return;
+    _debugLog(
+      'event=helper_close activeRequests=${_activeCancelTokens.length} '
+      'activeReaders=${_activeReaders.length}',
+    );
+    _isClosed = true;
+    for (final CancelToken cancelToken in List<CancelToken>.of(
+      _activeCancelTokens,
+    )) {
+      cancelToken.cancel('Enrollment certificate helper closed');
+    }
+    for (final _ResponseStreamReader reader in List<_ResponseStreamReader>.of(
+      _activeReaders,
+    )) {
+      unawaited(reader.cancel());
+    }
+    _dio.close(force: true);
+  }
+}
+
+class _BufferedResponse {
+  const _BufferedResponse(this.statusCode, this.bytes);
+
+  final int statusCode;
+  final Uint8List bytes;
+}
+
+class _ResponseStreamReader {
+  _ResponseStreamReader(this._stream, {required this.maxBytes}) {
+    // Cancellation can be requested synchronously from a stream's onListen
+    // callback. Keep that typed error handled until _readBounded awaits it.
+    result.ignore();
+  }
+
+  final Stream<Uint8List> _stream;
+  final int maxBytes;
+  final BytesBuilder _builder = BytesBuilder(copy: false);
+  final Completer<Uint8List> _completer = Completer<Uint8List>();
+  late final Future<Uint8List> result = _completer.future;
+
+  StreamSubscription<Uint8List>? _subscription;
+  Future<void>? _cancelFuture;
+  int _receivedBytes = 0;
+  bool _cancelRequested = false;
+  bool _isPaused = false;
+
+  int get receivedBytes => _receivedBytes;
+
+  void startPaused() {
+    if (_subscription != null) return;
+    // Stored below and cancelled by cancel()/dispose().
+    // ignore: cancel_subscriptions
+    final StreamSubscription<Uint8List> subscription = _stream.listen(
+      _onData,
+      onError: _onError,
+      onDone: _onDone,
+      cancelOnError: true,
+    );
+    _subscription = subscription;
+    if (_cancelRequested) {
+      unawaited(_cancelSubscription());
+      return;
+    }
+    subscription.pause();
+    _isPaused = true;
+  }
+
+  void resume() {
+    if (!_isPaused || _cancelRequested) return;
+    _isPaused = false;
+    _subscription?.resume();
+  }
+
+  void _onData(Uint8List chunk) {
+    if (_completer.isCompleted) return;
+    _receivedBytes += chunk.length;
+    if (_receivedBytes > maxBytes) {
+      _completer.completeError(
+        const EnrollmentCertificateException(
+          EnrollmentCertificateExceptionKind.tooLarge,
+          'A RegWeb response exceeded the 10 MiB safety limit.',
+        ),
+        StackTrace.current,
+      );
+      unawaited(_cancelSubscription());
+      return;
+    }
+    _builder.add(chunk);
+  }
+
+  void _onError(Object error, StackTrace stackTrace) {
+    if (_completer.isCompleted) return;
+    _completer.completeError(error, stackTrace);
+  }
+
+  void _onDone() {
+    if (_completer.isCompleted) return;
+    _completer.complete(_builder.takeBytes());
+  }
+
+  Future<void> cancel() async {
+    _cancelRequested = true;
+    if (!_completer.isCompleted) {
+      _completer.completeError(
+        const EnrollmentCertificateException(
+          EnrollmentCertificateExceptionKind.cancelled,
+          'The enrollment certificate session is closed.',
+        ),
+        StackTrace.current,
+      );
+    }
+    await _cancelSubscription();
+  }
+
+  Future<void> dispose() async {
+    _cancelRequested = true;
+    await _cancelSubscription();
+  }
+
+  Future<void> _cancelSubscription() {
+    final StreamSubscription<Uint8List>? subscription = _subscription;
+    if (subscription == null) {
+      _cancelRequested = true;
+      return Future<void>.value();
+    }
+    return _cancelFuture ??= _cancelIgnoringErrors(subscription);
+  }
+
+  static Future<void> _cancelIgnoringErrors(
+    StreamSubscription<Uint8List> subscription,
+  ) async {
+    try {
+      await subscription.cancel();
+    } on Object {
+      // Cleanup must not replace the typed download failure already selected.
+    }
+  }
+}

--- a/packages/nsysu_crawler/test/enrollment_certificate_helper_test.dart
+++ b/packages/nsysu_crawler/test/enrollment_certificate_helper_test.dart
@@ -1,0 +1,748 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:nsysu_crawler/nsysu_crawler.dart';
+import 'package:test/test.dart';
+
+const String _loginUrl = 'https://regweb.nsysu.edu.tw/webreg/wregloginchk2.asp';
+const String _contextUrl =
+    'https://regweb.nsysu.edu.tw/webreg/'
+    'WRegMain3.asp?act=71&out=print/enrollcert.asp';
+const String _certificateUrl =
+    'https://regweb.nsysu.edu.tw/webreg/print/enrollcert.asp';
+const String _mainReferer = 'https://regweb.nsysu.edu.tw/webreg/WRegMain3.asp';
+const int _maxResponseBytes = 10 * 1024 * 1024;
+
+void main() {
+  group('EnrollmentCertificateHelper flow', () {
+    test(
+      'uses the exact three-request session and normalizes the PDF',
+      () async {
+        final Uint8List pdf = _validPdf();
+        final _FakeHttpClientAdapter adapter = _FakeHttpClientAdapter(<_Reply>[
+          _Reply.text(
+            '<html>login</html>',
+            headers: <String, List<String>>{
+              HttpHeaders.setCookieHeader: <String>[
+                'ASPSESSIONID=session-1; Path=/webreg/; Secure; HttpOnly',
+              ],
+            },
+          ),
+          _Reply.text('<html>context</html>'),
+          _Reply.bytes(
+            <int>[...ascii.encode(' \r\n\t'), ...pdf, ...ascii.encode('\r\n ')],
+            headers: <String, List<String>>{
+              // A valid signature is authoritative, not this misleading type.
+              HttpHeaders.contentTypeHeader: <String>['text/html'],
+            },
+          ),
+        ]);
+        final EnrollmentCertificateHelper helper = _helper(adapter);
+        addTearDown(helper.close);
+
+        final Uint8List result = await helper.download(
+          username: ' B123456789 ',
+          password: 'secret',
+        );
+
+        expect(result, orderedEquals(pdf));
+        expect(adapter.requests, hasLength(3));
+        expect(
+          adapter.requests.map((_RecordedRequest request) => request.method),
+          orderedEquals(<String>['POST', 'GET', 'POST']),
+        );
+        expect(
+          adapter.requests.map((_RecordedRequest request) => request.uri),
+          orderedEquals(<Uri>[
+            Uri.parse(_loginUrl),
+            Uri.parse(_contextUrl),
+            Uri.parse(_certificateUrl),
+          ]),
+        );
+        expect(
+          _form(adapter.requests[0]),
+          equals(<String, String>{'ID': 'B123456789', 'passwd': 'secret'}),
+        );
+        expect(adapter.requests[1].body, isEmpty);
+        expect(
+          _form(adapter.requests[2]),
+          equals(<String, String>{'ssn1': 'idno', 'idno': 'B123456789'}),
+        );
+        expect(
+          _header(adapter.requests[0], HttpHeaders.contentTypeHeader),
+          startsWith(Headers.formUrlEncodedContentType),
+        );
+        expect(
+          _header(adapter.requests[2], HttpHeaders.contentTypeHeader),
+          startsWith(Headers.formUrlEncodedContentType),
+        );
+        expect(
+          _header(adapter.requests[0], HttpHeaders.userAgentHeader),
+          equals(
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
+            'AppleWebKit/537.36 Chrome/138 Safari/537.36',
+          ),
+        );
+        expect(_header(adapter.requests[0], HttpHeaders.refererHeader), isNull);
+        expect(
+          _header(adapter.requests[1], HttpHeaders.refererHeader),
+          equals(_mainReferer),
+        );
+        expect(
+          _header(adapter.requests[2], HttpHeaders.refererHeader),
+          equals(_mainReferer),
+        );
+        expect(
+          _header(adapter.requests[1], HttpHeaders.cookieHeader),
+          contains('ASPSESSIONID=session-1'),
+        );
+        expect(
+          _header(adapter.requests[2], HttpHeaders.cookieHeader),
+          contains('ASPSESSIONID=session-1'),
+        );
+        for (final _RecordedRequest request in adapter.requests) {
+          expect(request.responseType, ResponseType.stream);
+          expect(request.followRedirects, isFalse);
+          expect(request.connectTimeout, const Duration(seconds: 30));
+          expect(request.sendTimeout, const Duration(seconds: 30));
+          expect(request.receiveTimeout, const Duration(seconds: 30));
+        }
+      },
+    );
+
+    test('default instances do not share cookies', () async {
+      Future<_FakeHttpClientAdapter> runSession(String sessionId) async {
+        final _FakeHttpClientAdapter adapter = _FakeHttpClientAdapter(<_Reply>[
+          _Reply.text(
+            'login',
+            headers: <String, List<String>>{
+              HttpHeaders.setCookieHeader: <String>[
+                'ASPSESSIONID=$sessionId; Path=/webreg/',
+              ],
+            },
+          ),
+          _Reply.text('context'),
+          _Reply.bytes(_validPdf()),
+        ]);
+        final EnrollmentCertificateHelper helper = _helper(adapter);
+        await helper.download(username: 'A1', password: 'password');
+        helper.close();
+        return adapter;
+      }
+
+      final _FakeHttpClientAdapter first = await runSession('first');
+      final _FakeHttpClientAdapter second = await runSession('second');
+
+      expect(_header(first.requests.first, HttpHeaders.cookieHeader), isNull);
+      expect(_header(second.requests.first, HttpHeaders.cookieHeader), isNull);
+      expect(
+        _header(second.requests[1], HttpHeaders.cookieHeader),
+        contains('ASPSESSIONID=second'),
+      );
+      expect(
+        _header(second.requests[1], HttpHeaders.cookieHeader),
+        isNot(contains('ASPSESSIONID=first')),
+      );
+    });
+
+    test('rejects missing credentials before making a request', () async {
+      final _FakeHttpClientAdapter adapter = _FakeHttpClientAdapter(<_Reply>[]);
+      final EnrollmentCertificateHelper helper = _helper(adapter);
+      addTearDown(helper.close);
+
+      await _expectKind(
+        helper.download(username: '  ', password: 'secret'),
+        EnrollmentCertificateExceptionKind.credentials,
+      );
+      expect(adapter.requests, isEmpty);
+    });
+
+    test('maps login 401 to a credentials failure', () async {
+      final _FakeHttpClientAdapter adapter = _FakeHttpClientAdapter(<_Reply>[
+        _Reply.text('unauthorized', statusCode: 401),
+      ]);
+      final EnrollmentCertificateHelper helper = _helper(adapter);
+      addTearDown(helper.close);
+
+      await expectLater(
+        helper.download(username: 'A1', password: 'wrong'),
+        throwsA(
+          isA<EnrollmentCertificateException>()
+              .having(
+                (EnrollmentCertificateException error) => error.kind,
+                'kind',
+                EnrollmentCertificateExceptionKind.credentials,
+              )
+              .having(
+                (EnrollmentCertificateException error) => error.statusCode,
+                'statusCode',
+                401,
+              ),
+        ),
+      );
+    });
+
+    test('maps an unsuccessful context status to http', () async {
+      final _FakeHttpClientAdapter adapter = _FakeHttpClientAdapter(<_Reply>[
+        _Reply.text('login'),
+        _Reply.text('server error', statusCode: 500),
+      ]);
+      final EnrollmentCertificateHelper helper = _helper(adapter);
+      addTearDown(helper.close);
+
+      await expectLater(
+        helper.download(username: 'A1', password: 'password'),
+        throwsA(
+          isA<EnrollmentCertificateException>()
+              .having(
+                (EnrollmentCertificateException error) => error.kind,
+                'kind',
+                EnrollmentCertificateExceptionKind.http,
+              )
+              .having(
+                (EnrollmentCertificateException error) => error.statusCode,
+                'statusCode',
+                500,
+              ),
+        ),
+      );
+    });
+  });
+
+  group('EnrollmentCertificateHelper redirects', () {
+    for (final int statusCode in <int>[301, 302, 303, 307, 308]) {
+      test(
+        'follows $statusCode manually with browser method semantics',
+        () async {
+          final _FakeHttpClientAdapter adapter = _FakeHttpClientAdapter(
+            <_Reply>[
+              _Reply.redirect(
+                statusCode,
+                'login-redirect.asp',
+                headers: <String, List<String>>{
+                  HttpHeaders.setCookieHeader: <String>[
+                    'ASPSESSIONID=redirect-cookie; Path=/webreg/',
+                  ],
+                },
+              ),
+              _Reply.text('login complete'),
+              _Reply.text('context'),
+              _Reply.bytes(_validPdf()),
+            ],
+          );
+          final EnrollmentCertificateHelper helper = _helper(adapter);
+          addTearDown(helper.close);
+
+          await helper.download(username: 'A1', password: 'password');
+
+          expect(adapter.requests, hasLength(4));
+          expect(
+            adapter.requests[1].uri,
+            Uri.parse('https://regweb.nsysu.edu.tw/webreg/login-redirect.asp'),
+          );
+          final bool preservesPost = statusCode == 307 || statusCode == 308;
+          expect(adapter.requests[1].method, preservesPost ? 'POST' : 'GET');
+          if (preservesPost) {
+            expect(
+              _form(adapter.requests[1]),
+              equals(<String, String>{'ID': 'A1', 'passwd': 'password'}),
+            );
+          } else {
+            expect(adapter.requests[1].body, isEmpty);
+          }
+          expect(
+            _header(adapter.requests[1], HttpHeaders.cookieHeader),
+            contains('ASPSESSIONID=redirect-cookie'),
+          );
+        },
+      );
+    }
+
+    for (final int statusCode in <int>[302, 307, 308]) {
+      test('rejects a $statusCode redirect to another host', () async {
+        final _FakeHttpClientAdapter adapter = _FakeHttpClientAdapter(<_Reply>[
+          _Reply.redirect(
+            statusCode,
+            'https://attacker.example/webreg/capture.asp',
+          ),
+        ]);
+        final EnrollmentCertificateHelper helper = _helper(adapter);
+        addTearDown(helper.close);
+
+        await _expectKind(
+          helper.download(username: 'A1', password: 'password'),
+          EnrollmentCertificateExceptionKind.redirect,
+        );
+        expect(adapter.requests, hasLength(1));
+      });
+    }
+
+    for (final String location in <String>[
+      'http://regweb.nsysu.edu.tw/webreg/insecure.asp',
+      'https://regweb.nsysu.edu.tw/outside.asp',
+      'https://regweb.nsysu.edu.tw:444/webreg/wrong-port.asp',
+      'https://regweb.nsysu.edu.tw/webreg/%2e%2e/outside.asp',
+    ]) {
+      test('rejects redirect target $location', () async {
+        final _FakeHttpClientAdapter adapter = _FakeHttpClientAdapter(<_Reply>[
+          _Reply.redirect(302, location),
+        ]);
+        final EnrollmentCertificateHelper helper = _helper(adapter);
+        addTearDown(helper.close);
+
+        await _expectKind(
+          helper.download(username: 'A1', password: 'password'),
+          EnrollmentCertificateExceptionKind.redirect,
+        );
+        expect(adapter.requests, hasLength(1));
+      });
+    }
+
+    test('stops after five followed redirects', () async {
+      final _FakeHttpClientAdapter adapter = _FakeHttpClientAdapter(
+        List<_Reply>.generate(
+          6,
+          (int index) => _Reply.redirect(302, 'hop-$index.asp'),
+        ),
+      );
+      final EnrollmentCertificateHelper helper = _helper(adapter);
+      addTearDown(helper.close);
+
+      await _expectKind(
+        helper.download(username: 'A1', password: 'password'),
+        EnrollmentCertificateExceptionKind.redirect,
+      );
+      expect(adapter.requests, hasLength(6));
+    });
+
+    test('rejects redirect without Location', () async {
+      final _FakeHttpClientAdapter adapter = _FakeHttpClientAdapter(<_Reply>[
+        _Reply.text('', statusCode: 302),
+      ]);
+      final EnrollmentCertificateHelper helper = _helper(adapter);
+      addTearDown(helper.close);
+
+      await _expectKind(
+        helper.download(username: 'A1', password: 'password'),
+        EnrollmentCertificateExceptionKind.redirect,
+      );
+    });
+  });
+
+  group('EnrollmentCertificateHelper response validation', () {
+    test('does not trust an application/pdf Content-Type', () async {
+      final _FakeHttpClientAdapter adapter = _FakeHttpClientAdapter(<_Reply>[
+        _Reply.text('login'),
+        _Reply.text('context'),
+        _Reply.text(
+          '<html>login expired</html>',
+          headers: <String, List<String>>{
+            HttpHeaders.contentTypeHeader: <String>['application/pdf'],
+          },
+        ),
+      ]);
+      final EnrollmentCertificateHelper helper = _helper(adapter);
+      addTearDown(helper.close);
+
+      await _expectKind(
+        helper.download(username: 'A1', password: 'password'),
+        EnrollmentCertificateExceptionKind.invalidPdf,
+      );
+    });
+
+    test('requires a complete PDF of at least 1024 bytes', () async {
+      for (final Uint8List invalidPdf in <Uint8List>[
+        Uint8List.fromList(ascii.encode('%PDF-1.7\nshort\n%%EOF')),
+        Uint8List.fromList(<int>[
+          ...ascii.encode('%PDF-1.7\n'),
+          ...List<int>.filled(1100, 0x41),
+        ]),
+        Uint8List.fromList(<int>[0x58, ..._validPdf()]),
+        Uint8List.fromList(<int>[..._validPdf(), 0x58]),
+      ]) {
+        final _FakeHttpClientAdapter adapter = _FakeHttpClientAdapter(<_Reply>[
+          _Reply.text('login'),
+          _Reply.text('context'),
+          _Reply.bytes(invalidPdf),
+        ]);
+        final EnrollmentCertificateHelper helper = _helper(adapter);
+
+        await _expectKind(
+          helper.download(username: 'A1', password: 'password'),
+          EnrollmentCertificateExceptionKind.invalidPdf,
+        );
+        helper.close();
+      }
+    });
+
+    test('rejects oversized declared content before buffering it', () async {
+      final Completer<void> listened = Completer<void>();
+      final Completer<void> cancelled = Completer<void>();
+      late final StreamController<Uint8List> responseController;
+      responseController = StreamController<Uint8List>(
+        onListen: listened.complete,
+        onCancel: cancelled.complete,
+      );
+      addTearDown(responseController.close);
+      final _FakeHttpClientAdapter adapter = _FakeHttpClientAdapter(<_Reply>[
+        _Reply.text('login'),
+        _Reply.text('context'),
+        _Reply.stream(
+          responseController.stream,
+          headers: <String, List<String>>{
+            HttpHeaders.contentLengthHeader: <String>[
+              '${_maxResponseBytes + 1}',
+            ],
+          },
+        ),
+      ]);
+      final EnrollmentCertificateHelper helper = _helper(adapter);
+      addTearDown(helper.close);
+
+      await _expectKind(
+        helper.download(username: 'A1', password: 'password'),
+        EnrollmentCertificateExceptionKind.tooLarge,
+      );
+      expect(listened.isCompleted, isTrue);
+      expect(cancelled.isCompleted, isTrue);
+    });
+
+    test('bounds intermediate HTML responses too', () async {
+      final _FakeHttpClientAdapter adapter = _FakeHttpClientAdapter(<_Reply>[
+        _Reply.text(
+          'login page',
+          headers: <String, List<String>>{
+            HttpHeaders.contentLengthHeader: <String>[
+              '${_maxResponseBytes + 1}',
+            ],
+          },
+        ),
+      ]);
+      final EnrollmentCertificateHelper helper = _helper(adapter);
+      addTearDown(helper.close);
+
+      await _expectKind(
+        helper.download(username: 'A1', password: 'password'),
+        EnrollmentCertificateExceptionKind.tooLarge,
+      );
+      expect(adapter.requests, hasLength(1));
+    });
+
+    test('rejects a streamed body that crosses 10 MiB', () async {
+      final Uint8List oneMiB = Uint8List(1024 * 1024);
+      final Completer<void> cancelled = Completer<void>();
+      late final StreamController<Uint8List> responseController;
+      responseController = StreamController<Uint8List>(
+        onListen: () {
+          for (int index = 0; index < 10; index += 1) {
+            responseController.add(oneMiB);
+          }
+          responseController.add(Uint8List.fromList(<int>[0]));
+        },
+        onCancel: cancelled.complete,
+      );
+      addTearDown(responseController.close);
+      final _FakeHttpClientAdapter adapter = _FakeHttpClientAdapter(<_Reply>[
+        _Reply.text('login'),
+        _Reply.text('context'),
+        _Reply.stream(responseController.stream),
+      ]);
+      final EnrollmentCertificateHelper helper = _helper(adapter);
+      addTearDown(helper.close);
+
+      await _expectKind(
+        helper.download(username: 'A1', password: 'password'),
+        EnrollmentCertificateExceptionKind.tooLarge,
+      );
+      expect(cancelled.isCompleted, isTrue);
+    });
+  });
+
+  group('EnrollmentCertificateHelper transport failures', () {
+    final Map<DioExceptionType, EnrollmentCertificateExceptionKind> cases =
+        <DioExceptionType, EnrollmentCertificateExceptionKind>{
+          DioExceptionType.connectionTimeout:
+              EnrollmentCertificateExceptionKind.timeout,
+          DioExceptionType.cancel: EnrollmentCertificateExceptionKind.cancelled,
+          DioExceptionType.connectionError:
+              EnrollmentCertificateExceptionKind.network,
+        };
+
+    for (final MapEntry<DioExceptionType, EnrollmentCertificateExceptionKind>
+        entry
+        in cases.entries) {
+      test('maps ${entry.key.name} to ${entry.value.name}', () async {
+        final _FakeHttpClientAdapter adapter = _FakeHttpClientAdapter(<_Reply>[
+          _Reply.failure(entry.key),
+        ]);
+        final EnrollmentCertificateHelper helper = _helper(adapter);
+        addTearDown(helper.close);
+
+        await _expectKind(
+          helper.download(username: 'A1', password: 'password'),
+          entry.value,
+        );
+      });
+    }
+
+    test('close is idempotent and prevents another request', () async {
+      final _FakeHttpClientAdapter adapter = _FakeHttpClientAdapter(<_Reply>[]);
+      final EnrollmentCertificateHelper helper = _helper(adapter);
+
+      helper.close();
+      helper.close();
+
+      expect(adapter.isClosed, isTrue);
+      await _expectKind(
+        helper.download(username: 'A1', password: 'password'),
+        EnrollmentCertificateExceptionKind.cancelled,
+      );
+      expect(adapter.requests, isEmpty);
+    });
+
+    test('close cancels an active streamed response', () async {
+      final Completer<void> listened = Completer<void>();
+      final Completer<void> delivered = Completer<void>();
+      final Completer<void> cancelled = Completer<void>();
+      late final StreamController<Uint8List> responseController;
+      responseController = StreamController<Uint8List>(
+        onListen: () {
+          listened.complete();
+          responseController.add(Uint8List.fromList(<int>[1, 2, 3]));
+        },
+        onCancel: cancelled.complete,
+      );
+      addTearDown(responseController.close);
+      final Stream<Uint8List> observedStream = responseController.stream.map((
+        Uint8List chunk,
+      ) {
+        if (!delivered.isCompleted) delivered.complete();
+        return chunk;
+      });
+      final _FakeHttpClientAdapter adapter = _FakeHttpClientAdapter(<_Reply>[
+        _Reply.stream(observedStream),
+      ]);
+      final EnrollmentCertificateHelper helper = _helper(adapter);
+      final Future<Uint8List> download = helper.download(
+        username: 'A1',
+        password: 'password',
+      );
+      final Future<void> expectation = _expectKind(
+        download,
+        EnrollmentCertificateExceptionKind.cancelled,
+      );
+
+      await listened.future;
+      await delivered.future;
+      helper.close();
+
+      await expectation;
+      expect(cancelled.isCompleted, isTrue);
+      expect(adapter.isClosed, isTrue);
+    });
+  });
+}
+
+EnrollmentCertificateHelper _helper(_FakeHttpClientAdapter adapter) {
+  final Dio dio = Dio();
+  dio.httpClientAdapter = adapter;
+  return EnrollmentCertificateHelper(dio: dio);
+}
+
+Future<void> _expectKind(
+  Future<Uint8List> future,
+  EnrollmentCertificateExceptionKind kind,
+) {
+  return expectLater(
+    future,
+    throwsA(
+      isA<EnrollmentCertificateException>().having(
+        (EnrollmentCertificateException error) => error.kind,
+        'kind',
+        kind,
+      ),
+    ),
+  );
+}
+
+Uint8List _validPdf() {
+  final List<int> header = ascii.encode('%PDF-1.7\n');
+  final List<int> eof = ascii.encode('%%EOF');
+  final int fillerLength = 1024 - header.length - eof.length;
+  return Uint8List.fromList(<int>[
+    ...header,
+    ...List<int>.filled(fillerLength, 0x41),
+    ...eof,
+  ]);
+}
+
+Map<String, String> _form(_RecordedRequest request) {
+  return Uri.splitQueryString(utf8.decode(request.body));
+}
+
+String? _header(_RecordedRequest request, String name) {
+  for (final MapEntry<String, dynamic> entry in request.headers.entries) {
+    if (entry.key.toLowerCase() == name.toLowerCase()) {
+      return entry.value?.toString();
+    }
+  }
+  return null;
+}
+
+class _RecordedRequest {
+  const _RecordedRequest({required this.options, required this.body});
+
+  final RequestOptions options;
+  final Uint8List body;
+
+  String get method => options.method;
+  Uri get uri => options.uri;
+  Map<String, dynamic> get headers => options.headers;
+  ResponseType get responseType => options.responseType;
+  bool get followRedirects => options.followRedirects;
+  Duration? get connectTimeout => options.connectTimeout;
+  Duration? get sendTimeout => options.sendTimeout;
+  Duration? get receiveTimeout => options.receiveTimeout;
+}
+
+class _Reply {
+  const _Reply._({
+    required this.statusCode,
+    required this.bodyChunks,
+    this.headers = const <String, List<String>>{},
+    this.failureType,
+    this.responseStream,
+  });
+
+  factory _Reply.text(
+    String body, {
+    int statusCode = 200,
+    Map<String, List<String>> headers = const <String, List<String>>{},
+  }) {
+    return _Reply.bytes(
+      utf8.encode(body),
+      statusCode: statusCode,
+      headers: headers,
+    );
+  }
+
+  factory _Reply.bytes(
+    List<int> body, {
+    int statusCode = 200,
+    Map<String, List<String>> headers = const <String, List<String>>{},
+  }) {
+    return _Reply._(
+      statusCode: statusCode,
+      bodyChunks: <Uint8List>[Uint8List.fromList(body)],
+      headers: headers,
+    );
+  }
+
+  factory _Reply.stream(
+    Stream<Uint8List> stream, {
+    int statusCode = 200,
+    Map<String, List<String>> headers = const <String, List<String>>{},
+  }) {
+    return _Reply._(
+      statusCode: statusCode,
+      bodyChunks: const <Uint8List>[],
+      headers: headers,
+      responseStream: stream,
+    );
+  }
+
+  factory _Reply.redirect(
+    int statusCode,
+    String location, {
+    Map<String, List<String>> headers = const <String, List<String>>{},
+  }) {
+    return _Reply._(
+      statusCode: statusCode,
+      bodyChunks: <Uint8List>[Uint8List(0)],
+      headers: <String, List<String>>{
+        ...headers,
+        HttpHeaders.locationHeader: <String>[location],
+      },
+    );
+  }
+
+  factory _Reply.failure(DioExceptionType type) {
+    return _Reply._(
+      statusCode: 0,
+      bodyChunks: const <Uint8List>[],
+      failureType: type,
+    );
+  }
+
+  final int statusCode;
+  final List<Uint8List> bodyChunks;
+  final Map<String, List<String>> headers;
+  final DioExceptionType? failureType;
+  final Stream<Uint8List>? responseStream;
+
+  ResponseBody respond(RequestOptions options) {
+    switch (failureType) {
+      case DioExceptionType.connectionTimeout:
+        throw DioException.connectionTimeout(
+          timeout: const Duration(seconds: 30),
+          requestOptions: options,
+        );
+      case DioExceptionType.cancel:
+        throw DioException.requestCancelled(
+          requestOptions: options,
+          reason: 'test cancellation',
+        );
+      case DioExceptionType.connectionError:
+        throw DioException.connectionError(
+          requestOptions: options,
+          reason: 'test connection error',
+        );
+      case null:
+        return ResponseBody(
+          responseStream ?? Stream<Uint8List>.fromIterable(bodyChunks),
+          statusCode,
+          headers: headers,
+        );
+      case _:
+        throw StateError('Unsupported test failure: $failureType');
+    }
+  }
+}
+
+class _FakeHttpClientAdapter implements HttpClientAdapter {
+  _FakeHttpClientAdapter(this._replies);
+
+  final List<_Reply> _replies;
+  final List<_RecordedRequest> requests = <_RecordedRequest>[];
+  int _replyIndex = 0;
+  bool isClosed = false;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final BytesBuilder body = BytesBuilder(copy: false);
+    if (requestStream != null) {
+      await for (final Uint8List chunk in requestStream) {
+        body.add(chunk);
+      }
+    }
+    requests.add(_RecordedRequest(options: options, body: body.takeBytes()));
+    if (_replyIndex >= _replies.length) {
+      throw StateError('No fake response for request ${options.uri}');
+    }
+    final _Reply reply = _replies[_replyIndex];
+    _replyIndex += 1;
+    return reply.respond(options);
+  }
+
+  @override
+  void close({bool force = false}) {
+    isClosed = true;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   google_sign_in_dartio: ^0.3.0
   json_annotation: ^4.6.0
   package_info_plus: ^8.0.3
+  path_provider: ^2.1.5
   printing: 5.13.4
 
 dev_dependencies:

--- a/test/enrollment_certificate_cache_test.dart
+++ b/test/enrollment_certificate_cache_test.dart
@@ -1,0 +1,276 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nsysu_ap/utils/enroll_certificate/enroll_certificate_cache.dart';
+
+void main() {
+  late Directory temporaryDirectory;
+
+  setUp(() async {
+    temporaryDirectory = await Directory.systemTemp.createTemp(
+      'enrollment_certificate_cache_test_',
+    );
+  });
+
+  tearDown(() async {
+    await temporaryDirectory.delete(recursive: true);
+  });
+
+  EnrollCertificateCache createCache(String username) {
+    return EnrollCertificateCache(
+      username: username,
+      supportDirectoryProvider: () async => temporaryDirectory,
+    );
+  }
+
+  test('normalizes a valid PDF before saving and reads it back', () async {
+    final EnrollCertificateCache cache = createCache('B123456789');
+    final Uint8List pdf = _validPdf('certificate');
+    final Uint8List response = Uint8List.fromList(<int>[
+      ...' \t\r\n'.codeUnits,
+      ...pdf,
+      ...'\r\n '.codeUnits,
+    ]);
+
+    await cache.save(response);
+
+    expect(await cache.read(), pdf);
+    final File file = await _cachedPdfFile(temporaryDirectory);
+    expect(await file.readAsBytes(), pdf);
+  });
+
+  test('normalizes usernames and isolates different accounts', () async {
+    final EnrollCertificateCache normalizedCache = createCache(
+      '  b123456789  ',
+    );
+    final EnrollCertificateCache sameAccountCache = createCache('B123456789');
+    final EnrollCertificateCache otherAccountCache = createCache('B987654321');
+    final Uint8List pdf = _validPdf('first');
+
+    await normalizedCache.save(pdf);
+
+    expect(await sameAccountCache.read(), pdf);
+    expect(await otherAccountCache.read(), isNull);
+    final File file = await _cachedPdfFile(temporaryDirectory);
+    final String accountKey = sha256
+        .convert(utf8.encode('B123456789'))
+        .toString()
+        .substring(0, 16);
+    expect(file.path, endsWith('/enroll_certificate_$accountKey.pdf'));
+  });
+
+  test(
+    'rejects truncated, small, HTML-prefixed, and arbitrary-prefixed data',
+    () {
+      expect(
+        EnrollCertificateCache.extractPdf(
+          Uint8List.fromList('%PDF-1.4\ntruncated'.codeUnits),
+        ),
+        isNull,
+      );
+      expect(
+        EnrollCertificateCache.extractPdf(
+          Uint8List.fromList('%PDF-1.4\nsmall\n%%EOF'.codeUnits),
+        ),
+        isNull,
+      );
+      expect(
+        EnrollCertificateCache.extractPdf(
+          Uint8List.fromList(<int>[
+            ...'<html><body>'.codeUnits,
+            ..._validPdf('fake'),
+            ...'</body></html>'.codeUnits,
+          ]),
+        ),
+        isNull,
+      );
+      expect(
+        EnrollCertificateCache.extractPdf(
+          Uint8List.fromList(<int>[
+            ...'arbitrary-prefix'.codeUnits,
+            ..._validPdf('fake'),
+          ]),
+        ),
+        isNull,
+      );
+    },
+  );
+
+  test('rejects a PDF larger than ten MiB', () {
+    final Uint8List oversized = Uint8List(
+      EnrollCertificateCache.maximumPdfLength + 1,
+    );
+    oversized.setAll(0, '%PDF-'.codeUnits);
+    oversized.fillRange(5, oversized.length - 5, 0x20);
+    oversized.setAll(oversized.length - 5, '%%EOF'.codeUnits);
+
+    expect(EnrollCertificateCache.extractPdf(oversized), isNull);
+  });
+
+  test('validation failure preserves the existing cached PDF', () async {
+    final EnrollCertificateCache cache = createCache('B123456789');
+    final Uint8List original = _validPdf('original');
+    await cache.save(original);
+
+    await expectLater(
+      cache.save(Uint8List.fromList('<html>error</html>'.codeUnits)),
+      throwsFormatException,
+    );
+
+    expect(await cache.read(), original);
+  });
+
+  test('I/O failure before replacement preserves the existing PDF', () async {
+    final EnrollCertificateCache cache = createCache('B123456789');
+    final Uint8List original = _validPdf('original');
+    await cache.save(original);
+    final File file = await _cachedPdfFile(temporaryDirectory);
+    await Directory('${file.path}.tmp').create();
+
+    await expectLater(
+      cache.save(_validPdf('replacement')),
+      throwsA(isA<FileSystemException>()),
+    );
+
+    expect(await cache.read(), original);
+  });
+
+  test('atomically replaces an existing PDF after validation', () async {
+    final EnrollCertificateCache cache = createCache('B123456789');
+    await cache.save(_validPdf('old'));
+    final Uint8List replacement = _validPdf('new');
+
+    await cache.save(replacement);
+
+    expect(await cache.read(), replacement);
+    final Directory directory = Directory(
+      '${temporaryDirectory.path}/enroll_certificates',
+    );
+    final List<FileSystemEntity> artifacts = await directory.list().toList();
+    expect(
+      artifacts.where((FileSystemEntity item) => item.path.endsWith('.bak')),
+      isEmpty,
+    );
+    expect(
+      artifacts.where((FileSystemEntity item) => item.path.endsWith('.tmp')),
+      isEmpty,
+    );
+  });
+
+  test('deletes an invalid cached file when reading it', () async {
+    final EnrollCertificateCache cache = createCache('B123456789');
+    await cache.save(_validPdf('valid'));
+    final File file = await _cachedPdfFile(temporaryDirectory);
+    await file.writeAsBytes('<html>expired session</html>'.codeUnits);
+
+    expect(await cache.read(), isNull);
+    expect(await file.exists(), isFalse);
+  });
+
+  test(
+    'recovers a missing main file from backup before temporary data',
+    () async {
+      final EnrollCertificateCache cache = createCache('B123456789');
+      final Uint8List backupPdf = _validPdf('last-committed');
+      final Uint8List temporaryPdf = _validPdf('uncommitted');
+      await cache.save(backupPdf);
+      final File file = await _cachedPdfFile(temporaryDirectory);
+      final File backupFile = await file.rename('${file.path}.bak');
+      final File temporaryFile = File('${file.path}.tmp');
+      await temporaryFile.writeAsBytes(temporaryPdf, flush: true);
+
+      expect(await cache.read(), backupPdf);
+      expect(await file.readAsBytes(), backupPdf);
+      expect(await backupFile.exists(), isFalse);
+      expect(await temporaryFile.exists(), isFalse);
+    },
+  );
+
+  test(
+    'recovers a valid temporary file when no main or backup exists',
+    () async {
+      final EnrollCertificateCache cache = createCache('B123456789');
+      final Uint8List temporaryPdf = _validPdf('temporary');
+      await cache.save(temporaryPdf);
+      final File file = await _cachedPdfFile(temporaryDirectory);
+      final File temporaryFile = await file.rename('${file.path}.tmp');
+
+      expect(await cache.read(), temporaryPdf);
+      expect(await file.readAsBytes(), temporaryPdf);
+      expect(await temporaryFile.exists(), isFalse);
+    },
+  );
+
+  test('recovers a valid backup after deleting an invalid main file', () async {
+    final EnrollCertificateCache cache = createCache('B123456789');
+    final Uint8List backupPdf = _validPdf('backup');
+    await cache.save(backupPdf);
+    final File file = await _cachedPdfFile(temporaryDirectory);
+    final File backupFile = await file.copy('${file.path}.bak');
+    await file.writeAsString('<html>invalid main</html>', flush: true);
+
+    expect(await cache.read(), backupPdf);
+    expect(await file.readAsBytes(), backupPdf);
+    expect(await backupFile.exists(), isFalse);
+  });
+
+  test(
+    'rejects and deletes an oversized cache without reading it whole',
+    () async {
+      final EnrollCertificateCache cache = createCache('B123456789');
+      await cache.save(_validPdf('valid'));
+      final File file = await _cachedPdfFile(temporaryDirectory);
+      final RandomAccessFile oversizedFile = await file.open(
+        mode: FileMode.write,
+      );
+      await oversizedFile.truncate(EnrollCertificateCache.maximumPdfLength + 1);
+      await oversizedFile.close();
+
+      expect(await cache.read(), isNull);
+      expect(await file.exists(), isFalse);
+    },
+  );
+
+  test(
+    'clear removes the current account cache and replacement artifacts',
+    () async {
+      final EnrollCertificateCache cache = createCache('B123456789');
+      await cache.save(_validPdf('valid'));
+      final File file = await _cachedPdfFile(temporaryDirectory);
+      await File('${file.path}.tmp').writeAsString('stale');
+      await File('${file.path}.bak').writeAsString('stale');
+
+      await cache.clear();
+
+      expect(await file.exists(), isFalse);
+      expect(await File('${file.path}.tmp').exists(), isFalse);
+      expect(await File('${file.path}.bak').exists(), isFalse);
+    },
+  );
+}
+
+Future<File> _cachedPdfFile(Directory supportDirectory) async {
+  final Directory directory = Directory(
+    '${supportDirectory.path}/enroll_certificates',
+  );
+  final List<File> files = await directory
+      .list()
+      .where(
+        (FileSystemEntity item) => item is File && item.path.endsWith('.pdf'),
+      )
+      .cast<File>()
+      .toList();
+  expect(files, hasLength(1));
+  return files.single;
+}
+
+Uint8List _validPdf(String marker) {
+  return Uint8List.fromList(<int>[
+    ...'%PDF-1.4\n$marker\n'.codeUnits,
+    ...List<int>.filled(1100, 0x20),
+    ...'\n%%EOF'.codeUnits,
+  ]);
+}

--- a/test/enrollment_certificate_page_test.dart
+++ b/test/enrollment_certificate_page_test.dart
@@ -1,0 +1,326 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart' show DebugPrintCallback, debugPrint;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nsysu_ap/l10n/strings.g.dart';
+import 'package:nsysu_ap/pages/enroll_certificate/enroll_certificate_page.dart';
+import 'package:nsysu_crawler/nsysu_crawler.dart';
+
+void main() {
+  setUp(() {
+    LocaleSettings.setLocaleSync(AppLocale.zhHantTw);
+  });
+
+  testWidgets('uses an account cache without making a network request', (
+    WidgetTester tester,
+  ) async {
+    final Uint8List cachedPdf = _validPdf('cached');
+    int requests = 0;
+    Uint8List? displayedPdf;
+
+    await tester.pumpWidget(
+      _testApp(
+        cachedPdf: cachedPdf,
+        password: '',
+        download: ({required String username, required String password}) async {
+          requests++;
+          return _validPdf('network');
+        },
+        onBuildPdf: (Uint8List bytes) => displayedPdf = bytes,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(requests, 0);
+    expect(displayedPdf, orderedEquals(cachedPdf));
+    expect(
+      find.byKey(const ValueKey<String>('enroll-certificate-pdf')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('retrieves once and caches when no saved PDF exists', (
+    WidgetTester tester,
+  ) async {
+    final Uint8List downloadedPdf = _validPdf('downloaded');
+    int requests = 0;
+    Uint8List? savedPdf;
+
+    await tester.pumpWidget(
+      _testApp(
+        onSavePdf: (Uint8List bytes) => savedPdf = bytes,
+        download: ({required String username, required String password}) async {
+          requests++;
+          expect(username, 'B123456789');
+          expect(password, 'secret');
+          return downloadedPdf;
+        },
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(requests, 1);
+    expect(savedPdf, orderedEquals(downloadedPdf));
+  });
+
+  testWidgets('regenerate is single-flight and replaces the cached PDF', (
+    WidgetTester tester,
+  ) async {
+    final Uint8List cachedPdf = _validPdf('old');
+    final Uint8List replacementPdf = _validPdf('replacement');
+    final Completer<Uint8List> request = Completer<Uint8List>();
+    int requests = 0;
+    Uint8List? displayedPdf;
+    Uint8List? savedPdf;
+
+    await tester.pumpWidget(
+      _testApp(
+        cachedPdf: cachedPdf,
+        download: ({required String username, required String password}) {
+          requests++;
+          return request.future;
+        },
+        onBuildPdf: (Uint8List bytes) => displayedPdf = bytes,
+        onSavePdf: (Uint8List bytes) => savedPdf = bytes,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final Finder regenerate = find.byKey(
+      const ValueKey<String>('enroll-certificate-regenerate'),
+    );
+    await tester.tap(regenerate);
+    await tester.tap(regenerate);
+    await tester.pump();
+    expect(requests, 1);
+
+    request.complete(replacementPdf);
+    await tester.pumpAndSettle();
+
+    expect(displayedPdf, orderedEquals(replacementPdf));
+    expect(savedPdf, orderedEquals(replacementPdf));
+  });
+
+  testWidgets('failed regenerate keeps the old cached PDF visible', (
+    WidgetTester tester,
+  ) async {
+    final Uint8List cachedPdf = _validPdf('old');
+    Uint8List? displayedPdf;
+    int cacheWrites = 0;
+
+    await tester.pumpWidget(
+      _testApp(
+        cachedPdf: cachedPdf,
+        download: ({required String username, required String password}) =>
+            Future<Uint8List>.error(Exception('offline test failure')),
+        onBuildPdf: (Uint8List bytes) => displayedPdf = bytes,
+        onSavePdf: (Uint8List bytes) => cacheWrites++,
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const ValueKey<String>('enroll-certificate-regenerate')),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(displayedPdf, orderedEquals(cachedPdf));
+    expect(find.text(app.enrollCertificate.requestFailed), findsOneWidget);
+    expect(cacheWrites, 0);
+  });
+
+  testWidgets('cache write failure still displays the retrieved PDF', (
+    WidgetTester tester,
+  ) async {
+    final Uint8List downloadedPdf = _validPdf('downloaded');
+    Uint8List? displayedPdf;
+
+    await tester.pumpWidget(
+      _testApp(
+        download:
+            ({required String username, required String password}) async =>
+                downloadedPdf,
+        saveError: Exception('offline cache failure'),
+        onBuildPdf: (Uint8List bytes) => displayedPdf = bytes,
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(displayedPdf, orderedEquals(downloadedPdf));
+    expect(find.text(app.enrollCertificate.saveFailed), findsOneWidget);
+  });
+
+  testWidgets(
+    'debug trace identifies a typed failure without exposing secrets',
+    (WidgetTester tester) async {
+      const String username = 'DEBUG_USERNAME_SENTINEL';
+      const String password = 'DEBUG_PASSWORD_SENTINEL';
+      const String privateBody = '<html>DEBUG_BODY_SENTINEL</html>';
+      final DebugPrintCallback originalDebugPrint = debugPrint;
+      final List<String> logs = <String>[];
+      debugPrint = (String? message, {int? wrapWidth}) {
+        if (message != null) logs.add(message);
+      };
+      addTearDown(() => debugPrint = originalDebugPrint);
+
+      try {
+        await tester.pumpWidget(
+          _testApp(
+            username: username,
+            password: password,
+            download:
+                ({required String username, required String password}) async =>
+                    throw const EnrollmentCertificateException(
+                      EnrollmentCertificateExceptionKind.http,
+                      privateBody,
+                      statusCode: 503,
+                    ),
+          ),
+        );
+        await tester.pumpAndSettle();
+      } finally {
+        debugPrint = originalDebugPrint;
+      }
+
+      final String output = logs.join('\n');
+      expect(
+        output,
+        contains(
+          '[EnrollCertificatePage] event=retrieve_failure '
+          'kind=http status=503',
+        ),
+      );
+      for (final String secret in <String>[username, password, privateBody]) {
+        expect(output, isNot(contains(secret)));
+      }
+      expect(find.text(app.enrollCertificate.requestFailed), findsOneWidget);
+    },
+  );
+
+  testWidgets('leaving the page prevents a late request from writing cache', (
+    WidgetTester tester,
+  ) async {
+    final Completer<Uint8List> request = Completer<Uint8List>();
+    int cacheWrites = 0;
+    bool requestStarted = false;
+
+    await tester.pumpWidget(
+      _testApp(
+        download: ({required String username, required String password}) {
+          requestStarted = true;
+          return request.future;
+        },
+        onSavePdf: (Uint8List bytes) => cacheWrites++,
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+    expect(requestStarted, isTrue);
+    await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+
+    request.complete(_validPdf('late'));
+    await tester.pump();
+
+    expect(cacheWrites, 0);
+  });
+
+  testWidgets('download exports the currently displayed PDF and filename', (
+    WidgetTester tester,
+  ) async {
+    final Uint8List cachedPdf = _validPdf('cached');
+    Uint8List? exportedPdf;
+    String? exportedFileName;
+
+    await tester.pumpWidget(
+      _testApp(
+        cachedPdf: cachedPdf,
+        download:
+            ({required String username, required String password}) async =>
+                _validPdf('unused'),
+        exportPdf:
+            ({required Uint8List bytes, required String fileName}) async {
+              exportedPdf = bytes;
+              exportedFileName = fileName;
+              return true;
+            },
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const ValueKey<String>('enroll-certificate-download')),
+    );
+    await tester.pump();
+
+    expect(exportedPdf, orderedEquals(cachedPdf));
+    expect(exportedFileName, '${app.enrollCertificate.fileName}.pdf');
+  });
+
+  testWidgets('shows an error when the platform cannot export the PDF', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      _testApp(
+        cachedPdf: _validPdf('cached'),
+        download:
+            ({required String username, required String password}) async =>
+                _validPdf('unused'),
+        exportPdf:
+            ({required Uint8List bytes, required String fileName}) async =>
+                false,
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const ValueKey<String>('enroll-certificate-download')),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.text(app.enrollCertificate.downloadFailed), findsOneWidget);
+  });
+}
+
+Widget _testApp({
+  required EnrollmentCertificateDownload download,
+  Uint8List? cachedPdf,
+  String username = 'b123456789',
+  String password = 'secret',
+  void Function(Uint8List bytes)? onBuildPdf,
+  void Function(Uint8List bytes)? onSavePdf,
+  Object? saveError,
+  EnrollmentCertificatePdfExporter? exportPdf,
+}) {
+  return MaterialApp(
+    home: EnrollCertificatePage(
+      credentialsProvider: () => EnrollmentCertificateCredentials(
+        username: username,
+        password: password,
+      ),
+      downloadCertificate: download,
+      readCachedCertificate: ({required String username}) async => cachedPdf,
+      writeCachedCertificate:
+          ({required String username, required Uint8List bytes}) async {
+            if (saveError != null) throw saveError;
+            cachedPdf = bytes;
+            onSavePdf?.call(bytes);
+          },
+      exportPdf: exportPdf,
+      pdfViewBuilder: (BuildContext context, Uint8List bytes, String fileName) {
+        onBuildPdf?.call(bytes);
+        return const Center(child: Text('PDF ready'));
+      },
+    ),
+  );
+}
+
+Uint8List _validPdf(String marker) {
+  return Uint8List.fromList(<int>[
+    ...'%PDF-1.7\n$marker\n'.codeUnits,
+    ...List<int>.filled(1100, 0x20),
+    ...'\n%%EOF'.codeUnits,
+  ]);
+}


### PR DESCRIPTION
### **User description**
## 摘要

新增在學證明功能，使用目前登入帳密，透過 RegWeb 免驗證碼流程取得校方 PDF，並在 App 內提供預覽、重新提取與下載／匯出。

Closes #139

## 主要變更

- 在首頁側邊選單新增「在學證明」入口，補齊繁體中文與英文介面文字。
- 新增獨立的 RegWeb 登入與下載流程，維持同一 Cookie session 完成文件取得。
- 加入帳號別本機快取，優先顯示已儲存文件；重新提取失敗時保留原有 PDF。
- 支援快取原子替換與中斷恢復，避免更新失敗造成既有文件遺失。
- 限制重新導向範圍與回應大小，檢查 PDF 標頭及結尾，並處理逾時、無效回應與匯出失敗。
- 防止重複提取，離開頁面時取消進行中的請求。
- 新增 `path_provider` 直接依賴，更新相關套件鎖定版本。

## 測試

新增測試涵蓋：
- RegWeb 請求流程、Cookie 隔離、重新導向、PDF 驗證與請求取消。
- 快取帳號隔離、檔案驗證、替換失敗保護及中斷恢復。
- 頁面快取載入、重新提取、失敗保留舊文件、匯出與錯誤提示。


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- 新增在學證明提取功能。

- 透過校方系統自動獲取 PDF。

- 支援本機快取、預覽與匯出。

- 包含錯誤處理與全面測試。


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[使用者請求在學證明] --> B{檢查本機快取};
  B -- 快取命中 --> C[顯示快取文件];
  B -- 快取未命中 --> D[登入 RegWeb 系統];
  D --> E[從 RegWeb 提取 PDF];
  E --> F[儲存 PDF 至本機快取];
  F --> C;
  C --> G[提供預覽、下載/匯出];
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an enrollment certificate page for retrieving, viewing, regenerating, and downloading enrollment certificate PDFs.
  * Added certificate caching for faster access and improved offline resilience.
  * Added an “Enroll Certificate” option to the home menu.
  * Added English and Traditional Chinese translations for certificate statuses and errors.

* **Documentation**
  * Documented enrollment certificate extraction and registration-system support.

* **Bug Fixes**
  * Enrollment certificate cache is cleared when users log out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->